### PR TITLE
Allow JSON Body requests up to 100mb

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -13,7 +13,9 @@ const state = {
 };
 
 const app = express();
-app.use(express.json());
+app.use(express.json({
+  limit: config.get('server.bodyLimit')
+}));
 app.use(express.urlencoded({
   extended: false
 }));

--- a/app/config/custom-environment-variables.json
+++ b/app/config/custom-environment-variables.json
@@ -1,5 +1,6 @@
 {
   "server": {
+    "bodyLimit": "SERVER_BODYLIMIT",
     "logLevel": "SERVER_LOGLEVEL",
     "morganFormat": "SERVER_MORGANFORMAT",
     "port": "SERVER_PORT"

--- a/app/config/default.json
+++ b/app/config/default.json
@@ -1,5 +1,6 @@
 {
   "server": {
+    "bodyLimit": "100mb",
     "logLevel": "debug",
     "morganFormat": "dev",
     "port": "3000"

--- a/openshift/README.md
+++ b/openshift/README.md
@@ -16,6 +16,7 @@ In order to prepare an environment, you will need to ensure that all of the foll
 
 ```sh
 oc create -n 9f0fbe-<env> configmap ches-server-config \
+  --from-literal=SERVER_BODYLIMIT=100mb \
   --from-literal=SERVER_LOGLEVEL=info \
   --from-literal=SERVER_MORGANFORMAT=combined \
   --from-literal=SERVER_PORT=3000


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
This PR allows POST body content to be up to 100mb in size.
<!-- Why is this change required? What problem does it solve? -->
This overrides the default 100kb body size limit. As we are encoding our files into base64, this limit is quickly exceeded.
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
As of `express` 4.16.0, the `body-parser` library is not needed as it is reincluded with the base distribution of express.
Ref: https://stackoverflow.com/a/43626891