### PR TITLE
Validate Context Keys/variables match RegEx

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -113,6 +113,18 @@ The email merge API has a One to Many relationship between a template string and
 
 In order for a template to be successfully populated, it requires a context object which *should* contain the variables which will be replaced. For the most part, Nunjucks is intended to behave as a glorified string-replacement engine. In the event the Context object has extra variables that are not used by a Template, nothing happens. You can expect to see blank spots where the templated value should be at.
 
+**IMPORTANT**: All keys in the Context object (variable names in the template) *MUST* contain only alphanumeric or underscore.
+
+``` json
+{
+  "this_is_fine": {
+    "thisIsGood": "good key/variable",
+    "thisIs_Good_2": "fine key/variable"
+  },
+  "this is $%&*$!": "bad key/variable"
+}
+```
+
 ### Templating
 
 We currently leverage the Nunjucks library for templated variable replacement. Its syntax is similar to the well-used [Jinja2](https://jinja.palletsprojects.com) library from Python. We will outline the most common use cases and examples for the templating engine below. For full details on templating, refer to the Nunjucks documentation at <https://mozilla.github.io/nunjucks/templating.html>.
@@ -198,3 +210,4 @@ You can expect the template engine to yield the following:
 ``` sh
 "BAR everything"
 ```
+****

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -2220,8 +2220,7 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2239,13 +2238,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2258,18 +2255,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2372,8 +2366,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2383,7 +2376,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2396,20 +2388,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2426,7 +2415,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2499,8 +2487,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2510,7 +2497,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2586,8 +2572,7 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2617,7 +2602,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2635,7 +2619,6 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2674,13 +2657,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },

--- a/app/src/components/utils.js
+++ b/app/src/components/utils.js
@@ -24,7 +24,7 @@ const utils = {
    */
   toPascalCase: str => str.toLowerCase().replace(/\b\w/g, t => t.toUpperCase()),
 
-  /** Returns a true if the contexts pass validation, otherwise throws an exception with the vailidation error
+  /** Returns a true if the contexts pass validation, otherwise throws an exception with the validation error
    * @param {array} contexts The array of contexts from a mail merge request
    * @returns {boolean} true if all good
    * @throws Reason the `contexts` object is invalid
@@ -35,8 +35,24 @@ const utils = {
       if (entry.bcc && !Array.isArray(entry.bcc)) throw new Error('Invalid value `bcc`');
       if (entry.cc && !Array.isArray(entry.cc)) throw new Error('Invalid value `cc`');
       if (typeof entry.context !== 'object') throw new Error('Invalid value `context`');
+      utils.validateKeys(entry.context);
       return true;
     });
+  },
+
+  /** Returns a true if the object's keys pass validation, otherwise throws an exception with the validation error
+   * @param {object} obj a Javascript object
+   * @returns {boolean} true if all good
+   * @throws Reason the `key` object is invalid
+   */
+  validateKeys: obj => {
+    Object.keys(obj).forEach(k => {
+      if (obj[k] === Object(obj[k]))  {
+        return utils.validateKeys(obj[k]);
+      }
+      if (!/^\w+$/.test(k)) throw new Error(`Invalid field name (${k}) in \`context\`.  Only alphanumeric characters and underscore allowed.`);
+    });
+    return true;
   }
 };
 

--- a/app/src/docs/v1.api-spec.yaml
+++ b/app/src/docs/v1.api-spec.yaml
@@ -231,7 +231,7 @@ components:
             - fizz@gov.bc.ca
         context:
           type: object
-          description: A freeform JSON object of key-value pairs
+          description: A freeform JSON object of key-value pairs.  All keys must be alphanumeric or underscore.
           example:
             something:
               greeting: Hello

--- a/app/tests/unit/components/utils.spec.js
+++ b/app/tests/unit/components/utils.spec.js
@@ -75,7 +75,7 @@ describe('validateContexts', () => {
         to: ['foo@bar.com'],
         cc: ['baz@bar.com'],
         bcc: ['1@2.com', '3@4.com'],
-        context: { test: '123' }
+        context: { 'test': '123', 'this_is_a_valid_key_from_json_123': 'pass', 'subObject': {good: 'good key name'} }
       }];
     const result = utils.validateContexts(validObj);
 
@@ -138,5 +138,31 @@ describe('validateContexts', () => {
       }];
 
     expect(() => utils.validateContexts(invalidObj)).toThrow('Invalid value `context`');
+  });
+
+  it('should throw if context field is not an Alpha Numeric or Underscore', () => {
+    const invalidObj = [
+      {
+        'to': ['foo@bar.com'],
+        'context': {
+          'a1_&': 'bad key'
+        }
+      }];
+
+    expect(() => utils.validateContexts(invalidObj)).toThrow('Invalid field name (a1_&) in `context`.  Only alphanumeric characters and underscore allowed.');
+  });
+
+  it('should throw if context subobject field is not an Alpha Numeric of Underscore', () => {
+    const invalidObj = [
+      {
+        'to': ['foo@bar.com'],
+        'context': {
+          'subObject': {
+            'b2_&*(*&(*&)(* )()((* ab_cd_1_2_3': 'bad key'
+          }
+        }
+      }];
+
+    expect(() => utils.validateContexts(invalidObj)).toThrow('Invalid field name (b2_&*(*&(*&)(* )()((* ab_cd_1_2_3) in `context`.  Only alphanumeric characters and underscore allowed.');
   });
 });


### PR DESCRIPTION
Ensure that the incoming context keys are alphanumeric or underscore only.

<!-- Provide a general summary of your changes in the Title above -->
# Description
Want to limit our exposure to templating failures due to "bad" template substitution.  Enforce that variables (context object's keys) are alphanumeric or underscore.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
Documentation (non-breaking change with enhancements to documentation)
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->