### PR TITLE
Add and expose delayTS support to API

### DIFF
--- a/app/src/components/status.js
+++ b/app/src/components/status.js
@@ -1,15 +1,16 @@
-const queueComponent = require('./queue');
+const queue = require('./queue');
+const utils = require('./utils');
 
 const status = {
   getMessageId: async msgId => {
-    const job = await queueComponent.getMessage(msgId);
+    const job = await queue.getMessage(msgId);
     if (!job) {
       return null;
     }
 
     const status = await job.getState();
     const result = {
-      delayTS: job.timestamp + job.delay,
+      delayTS: utils.calculateDelayTS(job.opts.timestamp, job.opts.delay),
       msgId: job.id,
       status: status,
       timestamp: job.timestamp,

--- a/app/src/components/utils.js
+++ b/app/src/components/utils.js
@@ -1,4 +1,18 @@
 const utils = {
+  /** Calculates the difference in delay relative to now
+   *  @param {integer} delayTS Desired UTC time to delay to
+   *  @returns {integer} Number of milliseconds `delayTS` is in the future
+   *    If `delayTS` is now or in the past, it will return 0
+   */
+  calculateDelayMS: delayTS => Math.max(delayTS - Date.now(), 0),
+
+  /** Calculates the delay relative to a provided timestamp
+   *  @param {integer} delay Number of milliseconds to delay
+   *  @param {integer} timestamp Reference UTC time
+   *  @returns {integer} A UTC time with the delay added
+   */
+  calculateDelayTS: (delay, timestamp) => timestamp + delay,
+
   /** Returns a new object where undefined and empty arrays are dropped
    *  @param {object} obj A JSON Object
    *  @returns {object} A JSON Object without empty arrays and undefined properties

--- a/app/src/docs/v1.api-spec.yaml
+++ b/app/src/docs/v1.api-spec.yaml
@@ -503,6 +503,10 @@ components:
           description: A corresponding message uuid
           format: uuid
           example: 00000000-0000-0000-0000-000000000000
+        tag:
+          type: string
+          description: A unique string which is associated with the message
+          example: tag
         to:
           type: array
           items:
@@ -622,10 +626,10 @@ components:
       properties:
         type:
           type: string
-          description: What type of problem, link to explanation of problem
+          description: 'What type of problem, link to explanation of problem'
         title:
           type: string
-          description: Title of problem, generally the Http Status Code description
+          description: 'Title of problem, generally the Http Status Code description'
         status:
           type: string
           description: The Http Status code
@@ -646,7 +650,9 @@ components:
           example: 00000000-0000-0000-0000-000000000000
         result:
           type: object
-          description: A subset of the SMTP server response if message was sent
+          description: >-
+            A SMTP server response with Personally Identifiable information
+            removed. This object should only appear if the message was sent.
           properties:
             smtpMsgId:
               type: string
@@ -655,7 +661,10 @@ components:
             response:
               type: string
               description: X
-              example: 250 2.6.0 <00000000-0000-0000-0000-000000000000@gov.bc.ca> [InternalId=00000000000000, Hostname=some.server.ca] 1524 bytes in 0.218, 6.814 KB/sec Queued mail for delivery
+              example: >-
+                250 2.6.0 <00000000-0000-0000-0000-000000000000@gov.bc.ca>
+                [InternalId=00000000000000, Hostname=some.server.ca] 1524 bytes
+                in 0.218, 6.814 KB/sec Queued mail for delivery
         status:
           type: string
           description: (DRAFT) The state of this message in the queue
@@ -713,11 +722,11 @@ components:
                   value:
                     type: object
                     description: Contents of the field that was in error.
-                    example: "utf-8x"
+                    example: utf-8x
                   message:
                     type: string
                     description: The error message for the field.
-                    example: "Invalid value `encoding`."
+                    example: Invalid value `encoding`.
   responses:
     BadRequest:
       description: Request is missing content or is malformed
@@ -742,7 +751,9 @@ components:
     UnauthorizedError:
       description: Access token is missing or invalid
     UnprocessableEntity:
-      description: The server was unable to process the contained instructions.  Generally validation error(s).
+      description: >-
+        The server was unable to process the contained instructions. Generally
+        validation error(s).
       content:
         application/json:
           schema:

--- a/app/src/routes/v1/email.js
+++ b/app/src/routes/v1/email.js
@@ -1,5 +1,6 @@
 const emailComponent = require('../../components/email');
 const queueComponent = require('../../components/queue');
+const utilsComponent = require('../../components/utils');
 
 const emailRouter = require('express').Router();
 const {
@@ -13,7 +14,10 @@ emailRouter.post('/', validateEmail, async (req, res, next) => {
       const result = await emailComponent.sendMailEthereal(req.body);
       res.status(201).json(result);
     } else {
-      const result = queueComponent.enqueue(req.body);
+      const { delayTS, ...message } = req.body;
+      const result = queueComponent.enqueue(message, {
+        delay: delayTS ? utilsComponent.calculateDelayMS(delayTS) : undefined
+      });
       res.status(201).json({
         msgId: result
       });

--- a/app/tests/unit/components/merge.spec.js
+++ b/app/tests/unit/components/merge.spec.js
@@ -17,19 +17,20 @@ const url = 'https://example.com';
 
 // Object Fixtures
 const contextEntry = {
-  'to': [
+  to: [
     'bar@example.com'
   ],
-  'cc': [
+  cc: [
     'baz@example.com'
   ],
-  'bcc': [
+  bcc: [
     'foo@example.com',
     'fizz@example.com'
   ],
-  'context': {
-    'foo': 'test'
-  }
+  context: {
+    foo: 'test'
+  },
+  delayTS: 1
 };
 const info = {
   messageId: '<b658f8ca-6296-ccf4-8306-87d57a0b4321@example.com>',
@@ -101,12 +102,14 @@ describe('mergeMailSmtp', () => {
   });
 
   it('should throw an error if any sending failed', async () => {
+    const noDelay = Object.assign({}, template);
+    delete noDelay.contexts[0].delayTS;
     spy.mockResolvedValueOnce(info);
     spy.mockImplementation(() => {
       throw new Error(errorMessage);
     });
 
-    expect(merge.mergeMailSmtp(template)).rejects.toThrow(errorMessage);
+    expect(merge.mergeMailSmtp(noDelay)).rejects.toThrow(errorMessage);
   });
 });
 

--- a/app/tests/unit/components/status.spec.js
+++ b/app/tests/unit/components/status.spec.js
@@ -33,10 +33,12 @@ describe('getMessageId', () => {
   it('should return a delayed status', async () => {
     const queueStatus = 'delayed';
     spy.mockResolvedValue({
-      delay: delay,
       id: msgId,
       getState: jest.fn(() => queueStatus),
-      timestamp: timestamp
+      opts: {
+        delay: delay,
+        timestamp: timestamp
+      }
     });
 
     const result = await status.getMessageId(msgId);
@@ -51,14 +53,16 @@ describe('getMessageId', () => {
   it('should return a completed status with result contents', async () => {
     const queueStatus = 'completed';
     spy.mockResolvedValue({
-      delay: delay,
       id: msgId,
       getState: jest.fn(() => queueStatus),
+      opts: {
+        delay: delay,
+        timestamp: timestamp
+      },
       returnvalue: {
         messageId: smtpMsgId,
         response: 'response'
-      },
-      timestamp: timestamp
+      }
     });
 
     const result = await status.getMessageId(msgId);
@@ -76,11 +80,13 @@ describe('getMessageId', () => {
   it('should return a completed status without result contents', async () => {
     const queueStatus = 'completed';
     spy.mockResolvedValue({
-      delay: delay,
       id: msgId,
       getState: jest.fn(() => queueStatus),
-      returnvalue: {},
-      timestamp: timestamp
+      opts: {
+        delay: delay,
+        timestamp: timestamp
+      },
+      returnvalue: {}
     });
 
     const result = await status.getMessageId(msgId);

--- a/app/tests/unit/components/utils.spec.js
+++ b/app/tests/unit/components/utils.spec.js
@@ -3,6 +3,45 @@ const utils = require('../../../src/components/utils');
 
 helper.logHelper();
 
+describe('calculateDelayMS', () => {
+  it('should return an appropriate delay difference', () => {
+    const delayTS = Date.now() + 60000;
+
+    const result = utils.calculateDelayMS(delayTS);
+
+    expect(result).toBeTruthy();
+    expect(result).toBeGreaterThan(59900);
+    expect(result).toBeLessThan(60100);
+  });
+
+  it('should return 0 when delay is in the past', () => {
+    const delayTS = Date.now() - 60000;
+    const result = utils.calculateDelayMS(delayTS);
+
+    expect(result).toBeFalsy();
+    expect(result).toBe(0);
+  });
+});
+
+describe('calculateDelayTS', () => {
+  it('should return the correct delayed UTC time', () => {
+    const delay = 60000;
+    const result = utils.calculateDelayTS(delay, Date.now());
+
+    expect(result).toBeTruthy();
+    expect(result).toBeGreaterThan(Date.now() + 59900);
+    expect(result).toBeLessThan(Date.now() + 60100);
+  });
+
+  it('should return 0 when delay is in the past', () => {
+    const delayTS = Date.now() - 60000;
+    const result = utils.calculateDelayMS(delayTS);
+
+    expect(result).toBeFalsy();
+    expect(result).toBe(0);
+  });
+});
+
 describe('filterUndefinedAndEmpty', () => {
   const obj = {
     foo: undefined,

--- a/app/tests/unit/routes/v1/email.spec.js
+++ b/app/tests/unit/routes/v1/email.spec.js
@@ -54,9 +54,11 @@ describe(`POST ${basePath}`, () => {
     const response = await request(app).post(`${basePath}`).send({
       bodyType: 'text',
       body: 'body',
+      delayTS: 1,
       from: 'email@email.com',
       to: ['email@email.com'],
-      subject: 'subject'
+      subject: 'subject',
+      tag: 'tag'
     });
 
     expect(response.statusCode).toBe(201);
@@ -75,9 +77,11 @@ describe(`POST ${basePath}`, () => {
     const response = await request(app).post(`${basePath}`).send({
       bodyType: 'text',
       body: 'body',
+      delayTS: 0,
       from: 'email@email.com',
       to: ['email@email.com'],
-      subject: 'subject'
+      subject: 'subject',
+      tag: 'tag'
     });
 
     expect(response.statusCode).toBe(500);


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
This PR implements delayTS support in the API by exposing the delay support from Bull Queue.
Other enhancements:
* Add tag attribute to /email and /emailMerge endpoint responses
<!-- Why is this change required? What problem does it solve? -->
This PR will enable users to be able to delay sending email messages until a specified time (implemented via UTC unix time).
<!-- If it fixes an open issue, please link to the issue here. -->
[[SHOWCASE-250]](https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-250)

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
Documentation (non-breaking change with enhancements to documentation)
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the OpenAPI 3.0 `v*.api-spec.yaml` documentation (if appropriate)
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
