### PR TITLE
Change Redis Deployment to be backed by a PVC

### DIFF
--- a/Jenkinsfile.cicd
+++ b/Jenkinsfile.cicd
@@ -255,7 +255,7 @@ def deployStage(String stageEnv, String projectEnv, String hostRouteEnv) {
       timeout(10) {
         echo "Processing DeploymentConfig Redis.."
         def dcRedisTemplate = openshift.process('-f',
-          'openshift/redis.dc.yaml',
+          'openshift/redis-ephemeral.dc.yaml',
           "REPO_NAME=${REPO_NAME}",
           "JOB_NAME=${JOB_NAME}",
           "APP_NAME=${APP_NAME}"

--- a/openshift/redis-ephemeral.dc.yaml
+++ b/openshift/redis-ephemeral.dc.yaml
@@ -65,9 +65,8 @@ objects:
                 key: password
                 name: redis-${JOB_NAME}-secret
         volumes:
-        - name: redis-${JOB_NAME}-data
-          persistentVolumeClaim:
-            claimName: redis-${JOB_NAME}
+        - emptyDir: {}
+          name: redis-${JOB_NAME}-data
     test: false
     triggers:
     - imageChangeParams:
@@ -80,17 +79,6 @@ objects:
           namespace: openshift
       type: ImageChange
     - type: ConfigChange
-- apiVersion: v1
-  kind: PersistentVolumeClaim
-  metadata:
-    name: redis-${JOB_NAME}
-  spec:
-    accessModes:
-      - ReadWriteOnce
-    storageClassName: ${REDIS_PERSISTENT_VOLUME_CLASS}
-    resources:
-      requests:
-        storage: '${REDIS_VOLUME_CAPACITY}'
 - apiVersion: v1
   kind: Service
   metadata:
@@ -117,13 +105,3 @@ parameters:
   description: Application name
   displayName: Application name
   required: true
-- name: REDIS_VOLUME_CAPACITY
-  description: Volume space available for Redis
-  displayName: Redis Volume Capacity
-  required: true
-  value: 2Gi
-- name: REDIS_PERSISTENT_VOLUME_CLASS
-  description: The class of the volume; gluster-file, gluster-block, gluster-file-db
-  displayName: Persistent Volume Class name
-  required: false
-  value: gluster-file


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
This PR modifies the Redis deployment to leverage an explicit PersistentVolumeClaim.
<!-- Why is this change required? What problem does it solve? -->
The PVC is required in order to ensure that we do not have data loss when the Redis pod exits.
<!-- If it fixes an open issue, please link to the issue here. -->
[[SHOWCASE-284]](https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-284)

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the OpenAPI 3.0 `v*.api-spec.yaml` documentation (if appropriate)
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
