### PR TITLE
Add High Availability Postgres infrastructure support via Patroni

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -265,34 +265,67 @@ def deployStage(String stageEnv, String projectEnv, String hostRouteEnv) {
         throw new Exception('Missing ConfigMaps and/or Secrets')
       }
 
-      if(openshift.selector('secret', "redis-${JOB_NAME}-secret").exists()) {
-        echo "Redis Secret already exists. Skipping..."
-      } else {
-        echo "Processing Redis Secret..."
-        def dcRedisSecretTemplate = openshift.process('-f',
-          'openshift/redis.secret.yaml',
-          "REPO_NAME=${REPO_NAME}",
-          "JOB_NAME=${JOB_NAME}",
-          "APP_NAME=${APP_NAME}"
-        )
-
-        echo "Creating Redis Secret..."
-        openshift.create(dcRedisSecretTemplate)
-      }
-
-      // Apply Redis Deployment
       timeout(10) {
-        echo "Processing DeploymentConfig Redis.."
-        def dcRedisTemplate = openshift.process('-f',
-          'openshift/redis.dc.yaml',
-          "REPO_NAME=${REPO_NAME}",
-          "JOB_NAME=${JOB_NAME}",
-          "APP_NAME=${APP_NAME}"
-        )
+        parallel(
+          Patroni: {
+            // Apply Patroni Secret
+            if(openshift.selector('secret', "patroni-${JOB_NAME}-secret").exists()) {
+              echo "Patroni Secret already exists. Skipping..."
+            } else {
+              echo "Processing Patroni Secret..."
+              def dcPatroniSecretTemplate = openshift.process('-f',
+                'openshift/patroni.secret.yaml',
+                "APP_DB_NAME=${APP_NAME}",
+                "INSTANCE=${JOB_NAME}"
+              )
 
-        echo "Applying Redis Deployment..."
-        def dcRedis = openshift.apply(dcRedisTemplate).narrow('dc')
-        dcRedis.rollout().status('--watch=true')
+              echo "Creating Patroni Secret..."
+              openshift.create(dcPatroniSecretTemplate)
+            }
+
+            // Apply Patroni Database
+            echo "Processing Patroni StatefulSet.."
+            def dcPatroniTemplate = openshift.process('-f',
+              'openshift/patroni.dc.yaml',
+              "APP_NAME=${APP_NAME}",
+              "INSTANCE=${JOB_NAME}"
+            )
+
+            echo "Applying Patroni StatefulSet..."
+            def dcPatroni = openshift.apply(dcPatroniTemplate).narrow('statefulset')
+            dcPatroni.rollout().status('--watch=true')
+          },
+          Redis: {
+            // Apply Redis Secret
+            if(openshift.selector('secret', "redis-${JOB_NAME}-secret").exists()) {
+              echo "Redis Secret already exists. Skipping..."
+            } else {
+              echo "Processing Redis Secret..."
+              def dcRedisSecretTemplate = openshift.process('-f',
+                'openshift/redis.secret.yaml',
+                "REPO_NAME=${REPO_NAME}",
+                "JOB_NAME=${JOB_NAME}",
+                "APP_NAME=${APP_NAME}"
+              )
+
+              echo "Creating Redis Secret..."
+              openshift.create(dcRedisSecretTemplate)
+            }
+
+            // Apply Redis Deployment
+            echo "Processing DeploymentConfig Redis.."
+            def dcRedisTemplate = openshift.process('-f',
+              'openshift/redis.dc.yaml',
+              "REPO_NAME=${REPO_NAME}",
+              "JOB_NAME=${JOB_NAME}",
+              "APP_NAME=${APP_NAME}"
+            )
+
+            echo "Applying Redis Deployment..."
+            def dcRedis = openshift.apply(dcRedisTemplate).narrow('dc')
+            dcRedis.rollout().status('--watch=true')
+          }
+        )
       }
 
       createDeploymentStatus(projectEnv, 'PENDING', hostRouteEnv)

--- a/Jenkinsfile.cicd
+++ b/Jenkinsfile.cicd
@@ -236,34 +236,67 @@ def deployStage(String stageEnv, String projectEnv, String hostRouteEnv) {
         throw new Exception('Missing ConfigMaps and/or Secrets')
       }
 
-      if(openshift.selector('secret', "redis-${JOB_NAME}-secret").exists()) {
-        echo "Redis Secret already exists. Skipping..."
-      } else {
-        echo "Processing Redis Secret..."
-        def dcRedisSecretTemplate = openshift.process('-f',
-          'openshift/redis.secret.yaml',
-          "REPO_NAME=${REPO_NAME}",
-          "JOB_NAME=${JOB_NAME}",
-          "APP_NAME=${APP_NAME}"
-        )
-
-        echo "Creating Redis Secret..."
-        openshift.create(dcRedisSecretTemplate)
-      }
-
-      // Apply Redis Deployment
       timeout(10) {
-        echo "Processing DeploymentConfig Redis.."
-        def dcRedisTemplate = openshift.process('-f',
-          'openshift/redis-ephemeral.dc.yaml',
-          "REPO_NAME=${REPO_NAME}",
-          "JOB_NAME=${JOB_NAME}",
-          "APP_NAME=${APP_NAME}"
-        )
+        parallel(
+          Patroni: {
+            // Apply Patroni Secret
+            if(openshift.selector('secret', "patroni-${JOB_NAME}-secret").exists()) {
+              echo "Patroni Secret already exists. Skipping..."
+            } else {
+              echo "Processing Patroni Secret..."
+              def dcPatroniSecretTemplate = openshift.process('-f',
+                'openshift/patroni.secret.yaml',
+                "APP_DB_NAME=${APP_NAME}",
+                "INSTANCE=${JOB_NAME}"
+              )
 
-        echo "Applying Redis Deployment..."
-        def dcRedis = openshift.apply(dcRedisTemplate).narrow('dc')
-        dcRedis.rollout().status('--watch=true')
+              echo "Creating Patroni Secret..."
+              openshift.create(dcPatroniSecretTemplate)
+            }
+
+            // Apply Patroni Database
+            echo "Processing Patroni StatefulSet.."
+            def dcPatroniTemplate = openshift.process('-f',
+              'openshift/patroni-ephemeral.dc.yaml',
+              "APP_NAME=${APP_NAME}",
+              "INSTANCE=${JOB_NAME}"
+            )
+
+            echo "Applying Patroni StatefulSet..."
+            def dcPatroni = openshift.apply(dcPatroniTemplate).narrow('statefulset')
+            dcPatroni.rollout().status('--watch=true')
+          },
+          Redis: {
+            // Apply Redis Secret
+            if(openshift.selector('secret', "redis-${JOB_NAME}-secret").exists()) {
+              echo "Redis Secret already exists. Skipping..."
+            } else {
+              echo "Processing Redis Secret..."
+              def dcRedisSecretTemplate = openshift.process('-f',
+                'openshift/redis.secret.yaml',
+                "REPO_NAME=${REPO_NAME}",
+                "JOB_NAME=${JOB_NAME}",
+                "APP_NAME=${APP_NAME}"
+              )
+
+              echo "Creating Redis Secret..."
+              openshift.create(dcRedisSecretTemplate)
+            }
+
+            // Apply Redis Deployment
+            echo "Processing DeploymentConfig Redis.."
+            def dcRedisTemplate = openshift.process('-f',
+              'openshift/redis-ephemeral.dc.yaml',
+              "REPO_NAME=${REPO_NAME}",
+              "JOB_NAME=${JOB_NAME}",
+              "APP_NAME=${APP_NAME}"
+            )
+
+            echo "Applying Redis Deployment..."
+            def dcRedis = openshift.apply(dcRedisTemplate).narrow('dc')
+            dcRedis.rollout().status('--watch=true')
+          }
+        )
       }
 
       createDeploymentStatus(projectEnv, 'PENDING', hostRouteEnv)

--- a/Jenkinsfile.cicd
+++ b/Jenkinsfile.cicd
@@ -255,17 +255,22 @@ def deployStage(String stageEnv, String projectEnv, String hostRouteEnv) {
             }
 
             // Apply Patroni Database
-            echo "Processing Patroni StatefulSet.."
-            def dcPatroniTemplate = openshift.process('-f',
-              'openshift/patroni-ephemeral.dc.yaml',
-              "APP_NAME=${APP_NAME}",
-              "INSTANCE=${JOB_NAME}"
-            )
+            if(openshift.selector('dc', "patroni-${JOB_NAME}").exists()) {
+              echo "Patroni Deployment already exists. Skipping..."
+            } else {
+              echo "Processing Patroni StatefulSet.."
+              def dcPatroniTemplate = openshift.process('-f',
+                'openshift/patroni-ephemeral.dc.yaml',
+                "APP_NAME=${APP_NAME}",
+                "INSTANCE=${JOB_NAME}"
+              )
 
-            echo "Applying Patroni StatefulSet..."
-            def dcPatroni = openshift.apply(dcPatroniTemplate).narrow('statefulset')
-            dcPatroni.rollout().status('--watch=true')
+              echo "Applying Patroni StatefulSet..."
+              def dcPatroni = openshift.apply(dcPatroniTemplate).narrow('statefulset')
+              dcPatroni.rollout().status('--watch=true')
+            }
           },
+
           Redis: {
             // Apply Redis Secret
             if(openshift.selector('secret', "redis-${JOB_NAME}-secret").exists()) {
@@ -284,17 +289,21 @@ def deployStage(String stageEnv, String projectEnv, String hostRouteEnv) {
             }
 
             // Apply Redis Deployment
-            echo "Processing DeploymentConfig Redis.."
-            def dcRedisTemplate = openshift.process('-f',
-              'openshift/redis-ephemeral.dc.yaml',
-              "REPO_NAME=${REPO_NAME}",
-              "JOB_NAME=${JOB_NAME}",
-              "APP_NAME=${APP_NAME}"
-            )
+            if(openshift.selector('dc', "redis-${JOB_NAME}").exists()) {
+              echo "Redis Deployment already exists. Skipping..."
+            } else {
+              echo "Processing DeploymentConfig Redis.."
+              def dcRedisTemplate = openshift.process('-f',
+                'openshift/redis-ephemeral.dc.yaml',
+                "REPO_NAME=${REPO_NAME}",
+                "JOB_NAME=${JOB_NAME}",
+                "APP_NAME=${APP_NAME}"
+              )
 
-            echo "Applying Redis Deployment..."
-            def dcRedis = openshift.apply(dcRedisTemplate).narrow('dc')
-            dcRedis.rollout().status('--watch=true')
+              echo "Applying Redis Deployment..."
+              def dcRedis = openshift.apply(dcRedisTemplate).narrow('dc')
+              dcRedis.rollout().status('--watch=true')
+            }
           }
         )
       }

--- a/app/config/custom-environment-variables.json
+++ b/app/config/custom-environment-variables.json
@@ -1,4 +1,10 @@
 {
+  "db": {
+    "database": "DB_DATABASE",
+    "host": "DB_HOST",
+    "username": "DB_USERNAME",
+    "password": "DB_PASSWORD"
+  },
   "keycloak": {
     "clientId": "KC_CLIENTID",
     "clientSecret": "KC_CLIENTSECRET",

--- a/app/config/default.json
+++ b/app/config/default.json
@@ -1,4 +1,8 @@
 {
+  "db": {
+    "database": "ches",
+    "host": "localhost"
+  },
   "keycloak": {
     "realm": "jbd6rnxw",
     "serverUrl": "https://sso-dev.pathfinder.gov.bc.ca/auth"

--- a/app/config/test.json
+++ b/app/config/test.json
@@ -1,4 +1,8 @@
 {
+  "db": {
+    "username": "username",
+    "password": "password"
+  },
   "keycloak": {
     "clientId": "clientId",
     "clientSecret": "clientSecret"

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -966,6 +966,11 @@
       "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
       "dev": true
     },
+    "buffer-writer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-2.0.0.tgz",
+      "integrity": "sha512-a7ZpuTZU1TRtnwyCNW3I5dc0wWNC3VR9S++Ewyk2HHZdrO3CQJqSpd+95Us590V6AL7JqUAH2IwZ/398PmNFgw=="
+    },
     "bull": {
       "version": "3.11.0",
       "resolved": "https://registry.npmjs.org/bull/-/bull-3.11.0.tgz",
@@ -1261,9 +1266,9 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "config": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/config/-/config-3.2.2.tgz",
-      "integrity": "sha512-rOsfIOAcG82AWouK4/vBS/OKz3UPl2T/kP0irExmXJJOoWg2CmdfPLdx56bCoMUMFNh+7soQkQWCUC8DyemiwQ==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/config/-/config-3.2.3.tgz",
+      "integrity": "sha512-pditxQzO+SkKX/2gs99YnUGEjmBVkTj2o/hGOgC0oYEU7QgLnVVDYmcSL6HiGels/8QtFJpFzi5iKYv4D0dalg==",
       "requires": {
         "json5": "^1.0.1"
       },
@@ -1706,9 +1711,9 @@
       }
     },
     "eslint": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.4.0.tgz",
-      "integrity": "sha512-WTVEzK3lSFoXUovDHEbkJqCVPEPwbhCq4trDktNI6ygs7aO41d4cDT0JFAT5MivzZeVLWlg7vHL+bgrQv/t3vA==",
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.5.1.tgz",
+      "integrity": "sha512-32h99BoLYStT1iq1v2P9uwpyznQ4M2jRiFB6acitKz52Gqn+vPaMDUTB1bYi1WN4Nquj2w+t+bimYUG83DC55A==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
@@ -1760,9 +1765,9 @@
           }
         },
         "glob-parent": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.0.0.tgz",
-          "integrity": "sha512-Z2RwiujPRGluePM6j699ktJYxmPpJKCfpGA13jz2hmFZC7gKetzrWvg5KN3+OsIFmydGyZ1AVwERCq1w/ZZwRg==",
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.0.tgz",
+          "integrity": "sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==",
           "dev": true,
           "requires": {
             "is-glob": "^4.0.1"
@@ -1819,9 +1824,9 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.0.0.tgz",
-          "integrity": "sha512-PaF/MduxijYYt7unVGRuds1vBC9bFxbNf+VWqhOClfdgy7RlVkQqt610ig1/yxTgsDIfW1cWDel5EBbOy3jdtQ==",
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",
+          "integrity": "sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ==",
           "dev": true
         }
       }
@@ -2263,7 +2268,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2281,11 +2287,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2298,15 +2306,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2409,7 +2420,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2419,6 +2431,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2431,17 +2444,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2458,6 +2474,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2530,7 +2547,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2540,6 +2558,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2615,7 +2634,8 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2645,6 +2665,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2662,6 +2683,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2700,11 +2722,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },
@@ -3376,9 +3400,9 @@
       }
     },
     "is-retry-allowed": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
-      "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
+      "integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg==",
       "dev": true
     },
     "is-stream": {
@@ -4510,9 +4534,9 @@
       "integrity": "sha512-TEHBNBPHv7Ie/0o3HXnb7xrPSSQmH1dXwQKRaMKDBGt/ZN54lvDVujP6hKkO/vjkIYL9rK8kHSG11+G42Nhxuw=="
     },
     "nodemon": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-1.19.2.tgz",
-      "integrity": "sha512-hRLYaw5Ihyw9zK7NF+9EUzVyS6Cvgc14yh8CAYr38tPxJa6UrOxwAQ351GwrgoanHCF0FalQFn6w5eoX/LGdJw==",
+      "version": "1.19.3",
+      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-1.19.3.tgz",
+      "integrity": "sha512-TBNKRmJykEbxpTniZBusqRrUTHIEqa2fpecbTQDQj1Gxjth7kKAPP296ztR0o5gPUWsiYbuEbt73/+XMYab1+w==",
       "dev": true,
       "requires": {
         "chokidar": "^2.1.5",
@@ -4906,6 +4930,11 @@
         "semver": "^5.1.0"
       }
     },
+    "packet-reader": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/packet-reader/-/packet-reader-1.0.0.tgz",
+      "integrity": "sha512-HAKu/fG3HpHFO0AA8WE8q2g+gBJaZ9MG7fcKk+IJPLTGAD6Psw4443l+9DGRbOIh3/aXr7Phy0TjilYivJo5XQ=="
+    },
     "parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -4995,6 +5024,62 @@
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
       "dev": true
     },
+    "pg": {
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-7.12.1.tgz",
+      "integrity": "sha512-l1UuyfEvoswYfcUe6k+JaxiN+5vkOgYcVSbSuw3FvdLqDbaoa2RJo1zfJKfPsSYPFVERd4GHvX3s2PjG1asSDA==",
+      "requires": {
+        "buffer-writer": "2.0.0",
+        "packet-reader": "1.0.0",
+        "pg-connection-string": "0.1.3",
+        "pg-pool": "^2.0.4",
+        "pg-types": "^2.1.0",
+        "pgpass": "1.x",
+        "semver": "4.3.2"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.2.tgz",
+          "integrity": "sha1-x6BxWKgL7dBSNVt3DYLWZA+AO+c="
+        }
+      }
+    },
+    "pg-connection-string": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-0.1.3.tgz",
+      "integrity": "sha1-2hhHsglA5C7hSSvq9l1J2RskXfc="
+    },
+    "pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw=="
+    },
+    "pg-pool": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-2.0.7.tgz",
+      "integrity": "sha512-UiJyO5B9zZpu32GSlP0tXy8J2NsJ9EFGFfz5v6PSbdz/1hBLX1rNiiy5+mAm5iJJYwfCv4A0EBcQLGWwjbpzZw=="
+    },
+    "pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "requires": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      }
+    },
+    "pgpass": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.2.tgz",
+      "integrity": "sha1-Knu0G2BltnkH6R2hsHwYR8h3swY=",
+      "requires": {
+        "split": "^1.0.0"
+      }
+    },
     "pify": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
@@ -5029,6 +5114,29 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
+    },
+    "postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA=="
+    },
+    "postgres-bytea": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
+      "integrity": "sha1-AntTPAqokOJtFy1Hz5zOzFIazTU="
+    },
+    "postgres-date": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.4.tgz",
+      "integrity": "sha512-bESRvKVuTrjoBluEcpv2346+6kgB7UlnqWZsnbnCccTNq/pqfj1j6oBaN5+b/NrDXepYUT/HKadqv3iS9lJuVA=="
+    },
+    "postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "requires": {
+        "xtend": "^4.0.0"
+      }
     },
     "prelude-ls": {
       "version": "1.1.2",
@@ -5805,6 +5913,14 @@
       "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
       "dev": true
     },
+    "split": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+      "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+      "requires": {
+        "through": "2"
+      }
+    },
     "split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -6118,8 +6234,7 @@
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
-      "dev": true
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "timed-out": {
       "version": "4.0.1",
@@ -6658,6 +6773,11 @@
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
       "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
       "dev": true
+    },
+    "xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
     },
     "y18n": {
       "version": "4.0.0",

--- a/app/package.json
+++ b/app/package.json
@@ -23,22 +23,23 @@
     "bull": "^3.11.0",
     "bytes": "^3.1.0",
     "compression": "^1.7.4",
-    "config": "^3.2.2",
+    "config": "^3.2.3",
     "express": "^4.17.1",
     "keycloak-connect": "^7.0.0",
     "morgan": "^1.9.1",
     "nodemailer": "^6.3.0",
     "npmlog": "^4.1.2",
     "nunjucks": "^3.2.0",
+    "pg": "^7.12.1",
     "tmp": "^0.1.0",
     "uuid": "^3.3.3",
     "validator": "^11.1.0"
   },
   "devDependencies": {
-    "eslint": "^6.4.0",
+    "eslint": "^6.5.1",
     "jest": "^24.9.0",
     "jest-sonar-reporter": "^2.0.0",
-    "nodemon": "^1.19.2",
+    "nodemon": "^1.19.3",
     "supertest": "^4.0.2"
   },
   "eslintConfig": {

--- a/openshift/app.dc.yaml
+++ b/openshift/app.dc.yaml
@@ -58,6 +58,23 @@ objects:
           env:
           - name: NODE_ENV
             value: production
+          - name: DB_DATABASE
+            valueFrom:
+              secretKeyRef:
+                key: app-db-name
+                name: "patroni-${JOB_NAME}-secret"
+          - name: DB_HOST
+            value: "patroni-${JOB_NAME}"
+          - name: DB_USERNAME
+            valueFrom:
+              secretKeyRef:
+                key: app-db-username
+                name: "patroni-${JOB_NAME}-secret"
+          - name: DB_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                key: app-db-password
+                name: "patroni-${JOB_NAME}-secret"
           - name: KC_CLIENTID
             valueFrom:
               secretKeyRef:

--- a/openshift/app.dc.yaml
+++ b/openshift/app.dc.yaml
@@ -69,7 +69,7 @@ objects:
                 key: password
                 name: ches-keycloak-secret
           - name: REDIS_HOST
-            value: "${APP_NAME}-redis-${JOB_NAME}"
+            value: "redis-${JOB_NAME}"
           - name: REDIS_PASSWORD
             valueFrom:
               secretKeyRef:

--- a/openshift/patroni-ephemeral.dc.yaml
+++ b/openshift/patroni-ephemeral.dc.yaml
@@ -1,0 +1,298 @@
+---
+apiVersion: v1
+kind: Template
+metadata:
+  annotations:
+    description: Patroni Postgresql database cluster, with ephemeral storage.
+    iconClass: icon-postgresql
+    openshift.io/display-name: Patroni Postgresql (Ephemeral)
+    openshift.io/long-description: This template deploys a patroni postgresql HA cluster
+      with ephemeral storage.
+    tags: postgresql
+  name: patroni-postgregsql-ephemeral
+labels:
+  app: "${APP_NAME}-${INSTANCE}"
+  app.kubernetes.io/instance: "${INSTANCE}"
+  app.kubernetes.io/component: database
+  app.kubernetes.io/name: patroni
+  app.kubernetes.io/managed-by: template
+  app.kubernetes.io/version: '10'
+  cluster-name: "${INSTANCE}"
+objects:
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: "${NAME}-${INSTANCE}"
+  spec:
+    ports:
+    - port: 5432
+      protocol: TCP
+      targetPort: 5432
+    selector:
+      cluster-name: "${INSTANCE}"
+      role: master
+      app.kubernetes.io/name: patroni
+    sessionAffinity: None
+    type: ClusterIP
+  status:
+    loadBalancer: {}
+- apiVersion: apps/v1
+  kind: StatefulSet
+  metadata:
+    name: "${NAME}-${INSTANCE}"
+  spec:
+    podManagementPolicy: OrderedReady
+    replicas: 2
+    revisionHistoryLimit: 10
+    selector:
+      matchLabels:
+        statefulset: "${NAME}-${INSTANCE}"
+    serviceName: "${NAME}-${INSTANCE}"
+    template:
+      metadata:
+        labels:
+          statefulset: "${NAME}-${INSTANCE}"
+          cluster-name: "${INSTANCE}"
+          app.kubernetes.io/name: patroni
+      spec:
+        affinity:
+          podAntiAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                  - ${NAME}-${INSTANCE}
+              topologyKey: "kubernetes.io/hostname"
+        containers:
+        - env:
+          - name: APP_DATABASE
+            valueFrom:
+              secretKeyRef:
+                key: app-db-name
+                name: "${NAME}-${INSTANCE}-secret"
+          - name: APP_USER
+            valueFrom:
+              secretKeyRef:
+                key: app-db-username
+                name: "${NAME}-${INSTANCE}-secret"
+          - name: APP_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                key: app-db-password
+                name: "${NAME}-${INSTANCE}-secret"
+          - name: POD_IP
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: status.podIP
+          - name: PATRONI_KUBERNETES_LABELS
+            value: '{"cluster-name": "${INSTANCE}", "app.kubernetes.io/name": "patroni"}'
+          - name: PATRONI_KUBERNETES_NAMESPACE
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.namespace
+          - name: PATRONI_SUPERUSER_USERNAME
+            valueFrom:
+              secretKeyRef:
+                key: superuser-username
+                name: "${NAME}-${INSTANCE}-secret"
+          - name: PATRONI_SUPERUSER_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                key: superuser-password
+                name: "${NAME}-${INSTANCE}-secret"
+          - name: PATRONI_REPLICATION_USERNAME
+            valueFrom:
+              secretKeyRef:
+                key: replication-username
+                name: "${NAME}-${INSTANCE}-secret"
+          - name: PATRONI_REPLICATION_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                key: replication-password
+                name: "${NAME}-${INSTANCE}-secret"
+          - name: PATRONI_LOG_LEVEL
+            value: WARNING
+          - name: PATRONI_NAME
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.name
+          - name: PATRONI_POSTGRESQL_DATA_DIR
+            value: "/home/postgres/pgdata/pgroot/data"
+          - name: PATRONI_POSTGRESQL_PGPASS
+            value: "/tmp/pgpass"
+          - name: PATRONI_POSTGRESQL_LISTEN
+            value: 0.0.0.0:5432
+          - name: PATRONI_RESTAPI_LISTEN
+            value: 0.0.0.0:8008
+          - name: PATRONI_SCOPE
+            value: "${INSTANCE}"
+          - name: POSTGRESQL_MAX_CONNECTIONS
+            value: '500'
+          - name: POSTGRESQL_MAX_PREPARED_TRANSACTIONS
+            value: '500'
+          image: "${IMAGE_REGISTRY}/${IMAGE_STREAM_NAMESPACE}/${IMAGE_STREAM_TAG}"
+          imagePullPolicy: Always
+          livenessProbe:
+            exec:
+              command:
+                - /usr/share/scripts/patroni/health_check.sh
+            initialDelaySeconds: 5
+            timeoutSeconds: 5
+            failureThreshold: 4
+          name: postgresql
+          ports:
+          - containerPort: 8008
+            protocol: TCP
+          - containerPort: 5432
+            protocol: TCP
+          resources:
+            requests:
+              cpu: ${CPU_REQUEST}
+              memory: ${MEMORY_REQUEST}
+            limits:
+              cpu: ${CPU_LIMIT}
+              memory: ${MEMORY_LIMIT}
+          terminationMessagePath: "/dev/termination-log"
+          terminationMessagePolicy: File
+          readinessProbe:
+            exec:
+              command:
+                - /usr/share/scripts/patroni/health_check.sh
+            initialDelaySeconds: 5
+            timeoutSeconds: 5
+            failureThreshold: 4
+          volumeMounts:
+          - mountPath: "/home/postgres/pgdata"
+            name: postgresql
+        dnsPolicy: ClusterFirst
+        restartPolicy: Always
+        schedulerName: default-scheduler
+        securityContext: {}
+        serviceAccountName: "${NAME}-${INSTANCE}"
+        terminationGracePeriodSeconds: 0
+        volumes:
+        - name: postgresql
+          emptyDir: {}
+    updateStrategy:
+      type: RollingUpdate
+- apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+    name: "${NAME}-${INSTANCE}"
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: Role
+  metadata:
+    name: "${NAME}-${INSTANCE}"
+  rules:
+  - apiGroups:
+    - ''
+    resources:
+    - services
+    verbs:
+    - create
+    - get
+    - list
+    - patch
+    - update
+    - watch
+    - delete
+  - apiGroups:
+    - ''
+    resources:
+    - configmaps
+    verbs:
+    - create
+    - get
+    - list
+    - patch
+    - update
+    - watch
+    - delete
+  - apiGroups:
+    - ''
+    resources:
+    - endpoints
+    verbs:
+    - get
+    - patch
+    - update
+    - create
+    - list
+    - watch
+    - delete
+  - apiGroups:
+    - ''
+    resources:
+    - pods
+    verbs:
+    - get
+    - list
+    - patch
+    - update
+    - watch
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: RoleBinding
+  metadata:
+    name: "${NAME}-${INSTANCE}"
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: Role
+    name: "${NAME}-${INSTANCE}"
+  subjects:
+  - kind: ServiceAccount
+    name: "${NAME}-${INSTANCE}"
+parameters:
+- name: APP_NAME
+  description: The name of the application which will use this database.
+  displayName: Application client name
+  required: true
+- name: NAME
+  description: The name of the application for labelling all artifacts.
+  displayName: Application Name
+  required: true
+  value: patroni
+- name: INSTANCE
+  description: The name of this instance of the application
+  displayName: Application Instance Name
+  required: true
+- name: IMAGE_REGISTRY
+  description: The base OpenShift docker registry
+  displayName: Docker Image Registry
+  required: true
+  value: docker-registry.default.svc:5000
+- name: IMAGE_STREAM_NAMESPACE
+  description: The OpenShift Namespace where the patroni and postgresql ImageStream
+    resides.
+  displayName: ImageStream Namespace
+  required: true
+  value: bcgov
+- name: IMAGE_STREAM_TAG
+  description: Patroni ImageTag
+  displayName: ImageStream Tag
+  required: true
+  value: patroni:v10-stable
+- name: CPU_REQUEST
+  description: Starting amount of CPU the container can use.
+  displayName: CPU Request
+  required: true
+  value: '250m'
+- name: CPU_LIMIT
+  description: Maximum amount of CPU the container can use.
+  displayName: CPU Limit
+  required: true
+  value: '1'
+- name: MEMORY_REQUEST
+  description: Starting amount of memory the container can use.
+  displayName: Memory Request
+  required: true
+  value: 256Mi
+- name: MEMORY_LIMIT
+  description: Maximum amount of memory the container can use.
+  displayName: Memory Limit
+  required: true
+  value: 512Mi

--- a/openshift/patroni.dc.yaml
+++ b/openshift/patroni.dc.yaml
@@ -1,0 +1,319 @@
+---
+apiVersion: v1
+kind: Template
+metadata:
+  annotations:
+    description: Patroni Postgresql database cluster, with persistent storage.
+    iconClass: icon-postgresql
+    openshift.io/display-name: Patroni Postgresql (Persistent)
+    openshift.io/long-description: This template deploys a patroni postgresql HA cluster
+      with persistent storage.
+    tags: postgresql
+  name: patroni-postgregsql-persistent
+labels:
+  app: "${NAME}-${INSTANCE}"
+  app.kubernetes.io/instance: "${INSTANCE}"
+  app.kubernetes.io/component: database
+  app.kubernetes.io/name: patroni
+  app.kubernetes.io/managed-by: template
+  app.kubernetes.io/version: '10'
+  cluster-name: "${INSTANCE}"
+objects:
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: "${NAME}-${INSTANCE}"
+  spec:
+    ports:
+    - port: 5432
+      protocol: TCP
+      targetPort: 5432
+    selector:
+      cluster-name: "${INSTANCE}"
+      role: master
+      app.kubernetes.io/name: patroni
+    sessionAffinity: None
+    type: ClusterIP
+  status:
+    loadBalancer: {}
+- apiVersion: apps/v1
+  kind: StatefulSet
+  metadata:
+    name: "${NAME}-${INSTANCE}"
+  spec:
+    podManagementPolicy: OrderedReady
+    replicas: 3
+    revisionHistoryLimit: 10
+    selector:
+      matchLabels:
+        statefulset: "${NAME}-${INSTANCE}"
+    serviceName: "${NAME}-${INSTANCE}"
+    template:
+      metadata:
+        labels:
+          statefulset: "${NAME}-${INSTANCE}"
+          cluster-name: "${INSTANCE}"
+          app.kubernetes.io/name: patroni
+      spec:
+        affinity:
+          podAntiAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                  - ${NAME}-${INSTANCE}
+              topologyKey: "kubernetes.io/hostname"
+        containers:
+        - env:
+          - name: APP_DATABASE
+            valueFrom:
+              secretKeyRef:
+                key: app-db-name
+                name: "${NAME}-${INSTANCE}-secret"
+          - name: APP_USER
+            valueFrom:
+              secretKeyRef:
+                key: app-db-username
+                name: "${NAME}-${INSTANCE}-secret"
+          - name: APP_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                key: app-db-password
+                name: "${NAME}-${INSTANCE}-secret"
+          - name: POD_IP
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: status.podIP
+          - name: PATRONI_KUBERNETES_LABELS
+            value: '{"cluster-name": "${INSTANCE}", "app.kubernetes.io/name": "patroni"}'
+          - name: PATRONI_KUBERNETES_NAMESPACE
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.namespace
+          - name: PATRONI_SUPERUSER_USERNAME
+            valueFrom:
+              secretKeyRef:
+                key: superuser-username
+                name: "${NAME}-${INSTANCE}-secret"
+          - name: PATRONI_SUPERUSER_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                key: superuser-password
+                name: "${NAME}-${INSTANCE}-secret"
+          - name: PATRONI_REPLICATION_USERNAME
+            valueFrom:
+              secretKeyRef:
+                key: replication-username
+                name: "${NAME}-${INSTANCE}-secret"
+          - name: PATRONI_REPLICATION_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                key: replication-password
+                name: "${NAME}-${INSTANCE}-secret"
+          - name: PATRONI_LOG_LEVEL
+            value: WARNING
+          - name: PATRONI_NAME
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.name
+          - name: PATRONI_POSTGRESQL_DATA_DIR
+            value: "/home/postgres/pgdata/pgroot/data"
+          - name: PATRONI_POSTGRESQL_PGPASS
+            value: "/tmp/pgpass"
+          - name: PATRONI_POSTGRESQL_LISTEN
+            value: 0.0.0.0:5432
+          - name: PATRONI_RESTAPI_LISTEN
+            value: 0.0.0.0:8008
+          - name: PATRONI_SCOPE
+            value: "${INSTANCE}"
+          - name: POSTGRESQL_MAX_CONNECTIONS
+            value: '500'
+          - name: POSTGRESQL_MAX_PREPARED_TRANSACTIONS
+            value: '500'
+          image: "${IMAGE_REGISTRY}/${IMAGE_STREAM_NAMESPACE}/${IMAGE_STREAM_TAG}"
+          imagePullPolicy: Always
+          livenessProbe:
+            exec:
+              command:
+                - /usr/share/scripts/patroni/health_check.sh
+            initialDelaySeconds: 5
+            timeoutSeconds: 5
+            failureThreshold: 4
+          name: postgresql
+          ports:
+          - containerPort: 8008
+            protocol: TCP
+          - containerPort: 5432
+            protocol: TCP
+          resources:
+            requests:
+              cpu: ${CPU_REQUEST}
+              memory: ${MEMORY_REQUEST}
+            limits:
+              cpu: ${CPU_LIMIT}
+              memory: ${MEMORY_LIMIT}
+          terminationMessagePath: "/dev/termination-log"
+          terminationMessagePolicy: File
+          readinessProbe:
+            exec:
+              command:
+                - /usr/share/scripts/patroni/health_check.sh
+            initialDelaySeconds: 5
+            timeoutSeconds: 5
+            failureThreshold: 4
+          volumeMounts:
+          - mountPath: "/home/postgres/pgdata"
+            name: postgresql
+        dnsPolicy: ClusterFirst
+        restartPolicy: Always
+        schedulerName: default-scheduler
+        securityContext: {}
+        serviceAccountName: "${NAME}-${INSTANCE}"
+        terminationGracePeriodSeconds: 0
+        volumes:
+        - name: postgresql
+          persistentVolumeClaim:
+            claimName: postgresql
+    updateStrategy:
+      type: RollingUpdate
+    volumeClaimTemplates:
+    - metadata:
+        annotations:
+          volume.beta.kubernetes.io/storage-class: "${STORAGE_CLASS}"
+        labels:
+          app: "${NAME}-${INSTANCE}"
+        name: postgresql
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: "${PVC_SIZE}"
+        storageClassName: "${STORAGE_CLASS}"
+- apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+    name: "${NAME}-${INSTANCE}"
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: Role
+  metadata:
+    name: "${NAME}-${INSTANCE}"
+  rules:
+  - apiGroups:
+    - ''
+    resources:
+    - services
+    verbs:
+    - create
+    - get
+    - list
+    - patch
+    - update
+    - watch
+    - delete
+  - apiGroups:
+    - ''
+    resources:
+    - configmaps
+    verbs:
+    - create
+    - get
+    - list
+    - patch
+    - update
+    - watch
+    - delete
+  - apiGroups:
+    - ''
+    resources:
+    - endpoints
+    verbs:
+    - get
+    - patch
+    - update
+    - create
+    - list
+    - watch
+    - delete
+  - apiGroups:
+    - ''
+    resources:
+    - pods
+    verbs:
+    - get
+    - list
+    - patch
+    - update
+    - watch
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: RoleBinding
+  metadata:
+    name: "${NAME}-${INSTANCE}"
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: Role
+    name: "${NAME}-${INSTANCE}"
+  subjects:
+  - kind: ServiceAccount
+    name: "${NAME}-${INSTANCE}"
+parameters:
+- name: NAME
+  description: The name of the application for labelling all artifacts.
+  displayName: Application Name
+  required: true
+  value: patroni
+- name: INSTANCE
+  description: The name of this instance of the application
+  displayName: Application Instance Name
+  required: true
+- name: IMAGE_REGISTRY
+  description: The base OpenShift docker registry
+  displayName: Docker Image Registry
+  required: true
+  value: docker-registry.default.svc:5000
+- name: IMAGE_STREAM_NAMESPACE
+  description: The OpenShift Namespace where the patroni and postgresql ImageStream
+    resides.
+  displayName: ImageStream Namespace
+  required: true
+  value: bcgov
+- name: IMAGE_STREAM_TAG
+  description: Patroni ImageTag
+  displayName: ImageStream Tag
+  required: true
+  value: patroni:v10-stable
+- name: CPU_REQUEST
+  description: Starting amount of CPU the container can use.
+  displayName: CPU Request
+  required: true
+  value: '250m'
+- name: CPU_LIMIT
+  description: Maximum amount of CPU the container can use.
+  displayName: CPU Limit
+  required: true
+  value: '1'
+- name: MEMORY_REQUEST
+  description: Starting amount of memory the container can use.
+  displayName: Memory Request
+  required: true
+  value: 128Mi
+- name: MEMORY_LIMIT
+  description: Maximum amount of memory the container can use.
+  displayName: Memory Limit
+  required: true
+  value: 256Mi
+- name: PVC_SIZE
+  description: The size of the persistent volume to create.
+  displayName: Persistent Volume Size
+  required: true
+  value: 2Gi
+- name: STORAGE_CLASS
+  description: The type of the persistent volume to create.
+  displayName: Persistent Volume Class
+  required: true
+  value: gluster-block

--- a/openshift/patroni.secret.yaml
+++ b/openshift/patroni.secret.yaml
@@ -1,0 +1,79 @@
+---
+apiVersion: v1
+kind: Template
+metadata:
+  annotations:
+    description: Patroni Postgresql database cluster secret generator
+    iconClass: icon-postgresql
+    openshift.io/display-name: Patroni Postgresql
+    openshift.io/long-description: This template creates a patroni postgresql secret.
+    tags: postgresql
+  name: patroni-pgsql-secret
+labels:
+  app.kubernetes.io/instance: "${INSTANCE}"
+  app.kubernetes.io/component: database
+  app.kubernetes.io/name: patroni
+  app.kubernetes.io/managed-by: template
+  app.kubernetes.io/version: '10'
+  cluster-name: "${INSTANCE}"
+objects:
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    name: "${NAME}-${INSTANCE}-secret"
+  stringData:
+    replication-username: "${PATRONI_REPLICATION_USERNAME}"
+    replication-password: "${PATRONI_REPLICATION_PASSWORD}"
+    superuser-username: "${PATRONI_SUPERUSER_USERNAME}"
+    superuser-password: "${PATRONI_SUPERUSER_PASSWORD}"
+    app-db-name: "${APP_DB_NAME}"
+    app-db-username: "${APP_DB_USERNAME}"
+    app-db-password: "${APP_DB_PASSWORD}"
+parameters:
+- name: NAME
+  description: The name of the application for labelling all artifacts.
+  displayName: Application Name
+  required: true
+  value: patroni
+- name: INSTANCE
+  description: The name of this instance of the application
+  displayName: Application Instance Name
+  required: true
+- name: APP_DB_NAME
+  description: Name of the application database
+  displayName: Application Database Name
+  required: true
+  value: app
+- name: APP_DB_USERNAME
+  description: Username of the application database
+  displayName: Application Database Username
+  required: true
+  value: app
+- name: APP_DB_PASSWORD
+  description: Password of the application database
+  displayName: Application Database Password
+  generate: expression
+  from: "[a-zA-Z0-9]{32}"
+  required: true
+- name: PATRONI_SUPERUSER_USERNAME
+  description: Username of the superuser account for initialization.
+  displayName: Superuser Username
+  required: true
+  value: postgres
+- name: PATRONI_SUPERUSER_PASSWORD
+  description: Password of the superuser account for initialization.
+  displayName: Superuser Passsword
+  generate: expression
+  from: "[a-zA-Z0-9]{32}"
+  required: true
+- name: PATRONI_REPLICATION_USERNAME
+  description: Username of the replication account for initialization.
+  displayName: Replication Username
+  required: true
+  value: replication
+- name: PATRONI_REPLICATION_PASSWORD
+  description: Password of the replication account for initialization.
+  displayName: Repication Passsword
+  generate: expression
+  from: "[a-zA-Z0-9]{32}"
+  required: true

--- a/openshift/redis-ephemeral.dc.yaml
+++ b/openshift/redis-ephemeral.dc.yaml
@@ -10,12 +10,12 @@ objects:
 - apiVersion: v1
   kind: DeploymentConfig
   metadata:
-    name: "${APP_NAME}-redis-${JOB_NAME}"
+    name: "redis-${JOB_NAME}"
   spec:
     replicas: 1
     selector:
       app: "${APP_NAME}-${JOB_NAME}"
-      deploymentconfig: "${APP_NAME}-redis-${JOB_NAME}"
+      deploymentconfig: "redis-${JOB_NAME}"
     strategy:
       resources: {}
       type: Rolling
@@ -23,7 +23,7 @@ objects:
       metadata:
         labels:
           app: "${APP_NAME}-${JOB_NAME}"
-          deploymentconfig: "${APP_NAME}-redis-${JOB_NAME}"
+          deploymentconfig: "redis-${JOB_NAME}"
       spec:
         containers:
         - image: docker-registry.default.svc:5000/openshift/redis:latest
@@ -36,7 +36,7 @@ objects:
             tcpSocket:
               port: 6379
             timeoutSeconds: 1
-          name: "${APP_NAME}-redis-${JOB_NAME}"
+          name: "redis-${JOB_NAME}"
           ports:
           - containerPort: 6379
             protocol: TCP
@@ -72,7 +72,7 @@ objects:
     - imageChangeParams:
         automatic: true
         containerNames:
-        - "${APP_NAME}-redis-${JOB_NAME}"
+        - "redis-${JOB_NAME}"
         from:
           kind: ImageStreamTag
           name: redis:latest
@@ -82,7 +82,7 @@ objects:
 - apiVersion: v1
   kind: Service
   metadata:
-    name: "${APP_NAME}-redis-${JOB_NAME}"
+    name: "redis-${JOB_NAME}"
   spec:
     ports:
     - name: 6379-tcp
@@ -91,7 +91,7 @@ objects:
       targetPort: 6379
     selector:
       app: "${APP_NAME}-${JOB_NAME}"
-      deploymentconfig: "${APP_NAME}-redis-${JOB_NAME}"
+      deploymentconfig: "redis-${JOB_NAME}"
 parameters:
 - name: REPO_NAME
   description: Application repository name

--- a/openshift/redis.dc.yaml
+++ b/openshift/redis.dc.yaml
@@ -10,12 +10,12 @@ objects:
 - apiVersion: v1
   kind: DeploymentConfig
   metadata:
-    name: "${APP_NAME}-redis-${JOB_NAME}"
+    name: "redis-${JOB_NAME}"
   spec:
     replicas: 1
     selector:
       app: "${APP_NAME}-${JOB_NAME}"
-      deploymentconfig: "${APP_NAME}-redis-${JOB_NAME}"
+      deploymentconfig: "redis-${JOB_NAME}"
     strategy:
       resources: {}
       type: Rolling
@@ -23,7 +23,7 @@ objects:
       metadata:
         labels:
           app: "${APP_NAME}-${JOB_NAME}"
-          deploymentconfig: "${APP_NAME}-redis-${JOB_NAME}"
+          deploymentconfig: "redis-${JOB_NAME}"
       spec:
         containers:
         - image: docker-registry.default.svc:5000/openshift/redis:latest
@@ -36,7 +36,7 @@ objects:
             tcpSocket:
               port: 6379
             timeoutSeconds: 1
-          name: "${APP_NAME}-redis-${JOB_NAME}"
+          name: "redis-${JOB_NAME}"
           ports:
           - containerPort: 6379
             protocol: TCP
@@ -73,7 +73,7 @@ objects:
     - imageChangeParams:
         automatic: true
         containerNames:
-        - "${APP_NAME}-redis-${JOB_NAME}"
+        - "redis-${JOB_NAME}"
         from:
           kind: ImageStreamTag
           name: redis:latest
@@ -94,7 +94,7 @@ objects:
 - apiVersion: v1
   kind: Service
   metadata:
-    name: "${APP_NAME}-redis-${JOB_NAME}"
+    name: "redis-${JOB_NAME}"
   spec:
     ports:
     - name: 6379-tcp
@@ -103,7 +103,7 @@ objects:
       targetPort: 6379
     selector:
       app: "${APP_NAME}-${JOB_NAME}"
-      deploymentconfig: "${APP_NAME}-redis-${JOB_NAME}"
+      deploymentconfig: "redis-${JOB_NAME}"
 parameters:
 - name: REPO_NAME
   description: Application repository name


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
This is an infrastructure change which introduces High Availability Postgres with the use of Patroni.
* Streamline Openshift deployments to skip re-deploying Redis and Patroni if they already exist
* Decouple Redis service from having the application name bound to it
* Add postgres database connection check to application on startup

<!-- Why is this change required? What problem does it solve? -->
In order to have some degree of reliable persistence, our team has decided that Postgres is the path forwards. This PR is a necessary backend infrastructure step to achieve that goal.
<!-- If it fixes an open issue, please link to the issue here. -->
[[SHOWCASE-313]](https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-313)

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the OpenAPI 3.0 `v*.api-spec.yaml` documentation (if appropriate)
- [x] I have added necessary documentation (if appropriate)

## Further comments
