### PR TITLE
Add Status Query endpoint support

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -80,7 +80,10 @@
       ],
       "indent": [
         "error",
-        2
+        2,
+        {
+          "SwitchCase": 1
+        }
       ],
       "linebreak-style": [
         "error",

--- a/app/src/components/transformer.js
+++ b/app/src/components/transformer.js
@@ -18,17 +18,17 @@ const transformer = {
     const result = {
       createdTS: msg.createdAt ? moment.utc(msg.createdAt).valueOf() : null,
       delayTS: msg.delayTimestamp ? moment.utc(Number(msg.delayTimestamp)).valueOf() : null,
-      msgId: msg.messageId,
-      status: msg.status,
+      msgId: msg.messageId ? msg.messageId : null,
+      status: msg.status ? msg.status : null,
       statusHistory: msg.statusHistory ? msg.statusHistory.map(h => {
         return {
           description: h.description,
           status: h.status,
           timestamp: moment.utc(h.createdAt).valueOf()
         };
-      }) : undefined,
+      }) : [],
       tag: msg.tag ? msg.tag : null,
-      txId: msg.transactionId,
+      txId: msg.transactionId ? msg.transactionId : null,
       updatedTS: msg.updatedAt ? moment.utc(msg.updatedAt).valueOf() : null
     };
 

--- a/app/src/components/transformer.js
+++ b/app/src/components/transformer.js
@@ -16,8 +16,8 @@ const transformer = {
    */
   toStatusResponse: msg => {
     const result = {
-      createdTimestamp: msg.createdAt ? moment.utc(msg.createdAt).valueOf() : undefined,
-      delayTS: msg.delayTimestamp ? moment.utc(Number(msg.delayTimestamp)).valueOf() : undefined,
+      createdTS: msg.createdAt ? moment.utc(msg.createdAt).valueOf() : null,
+      delayTS: msg.delayTimestamp ? moment.utc(Number(msg.delayTimestamp)).valueOf() : null,
       msgId: msg.messageId,
       status: msg.status,
       statusHistory: msg.statusHistory ? msg.statusHistory.map(h => {
@@ -27,12 +27,12 @@ const transformer = {
           timestamp: moment.utc(h.createdAt).valueOf()
         };
       }) : undefined,
-      tag: msg.tag,
+      tag: msg.tag ? msg.tag : null,
       txId: msg.transactionId,
-      updatedTimestamp: msg.updatedAt ? moment.utc(msg.updatedAt).valueOf() : undefined
+      updatedTS: msg.updatedAt ? moment.utc(msg.updatedAt).valueOf() : null
     };
 
-    return utils.dropNullAndUndefinedObject(result);
+    return utils.dropUndefinedObject(result);
   },
 
   /** @function transaction

--- a/app/src/components/transformer.js
+++ b/app/src/components/transformer.js
@@ -44,13 +44,13 @@ const transformer = {
    */
   toTransactionResponse: trxn => {
     const result = {
-      messages: trxn.messages.map(m => {
+      messages: trxn.messages ? trxn.messages.map(m => {
         return {
-          msgId: m.messageId,
-          to: m.email.to
+          msgId: m.messageId ? m.messageId : null,
+          to: (m.email && m.email.to) ? m.email.to : null
         };
-      }),
-      txId: trxn.transactionId
+      }) : [],
+      txId: trxn.transactionId ? trxn.transactionId : null
     };
 
     return result;

--- a/app/src/components/transformer.js
+++ b/app/src/components/transformer.js
@@ -1,32 +1,12 @@
 const moment = require('moment');
 
+const utils = require('./utils');
+
 /** @module transform
  *
- *  @exports transformer - transform data service models to api models
+ *  @exports transformer - Transforms between Data Service Models and API Models
  */
-
-class Transformer {
-
-  /** @function transaction
-   *  @description Transforms a Trxn model from the db into TransactionResponse for the api
-   *
-   *  @param {object} trxn - a Fully inflated Trxn
-   *  @returns TransactionResponse
-   *  @see Trxn
-   */
-  static transaction(trxn) {
-    const result = {
-      txId: trxn.transactionId
-    };
-    result.messages = trxn.messages.map(m => {
-      return {
-        msgId: m.messageId,
-        to: m.email.to
-      };
-    });
-    return result;
-  }
-
+const transformer = {
   /** @function status
    *  @description Transforms a Message model from the db into a StatusResponse API object
    *
@@ -34,12 +14,12 @@ class Transformer {
    *  @returns {object} StatusResponse
    *  @see Message
    */
-  static status(msg) {
+  toStatusResponse: msg => {
     const result = {
       createdTimestamp: msg.createdAt ? moment.utc(msg.createdAt).valueOf() : undefined,
       delayTS: msg.delayTimestamp ? moment.utc(Number(msg.delayTimestamp)).valueOf() : undefined,
-      msgId: msg.messageId ? msg.messageId : undefined,
-      status: msg.status ? msg.status : undefined,
+      msgId: msg.messageId,
+      status: msg.status,
       statusHistory: msg.statusHistory ? msg.statusHistory.map(h => {
         return {
           description: h.description,
@@ -47,12 +27,34 @@ class Transformer {
           timestamp: moment.utc(h.createdAt).valueOf()
         };
       }) : undefined,
-      tag: msg.tag ? msg.tag : undefined,
-      txId: msg.transactionId ? msg.transactionId : undefined,
+      tag: msg.tag,
+      txId: msg.transactionId,
       updatedTimestamp: msg.updatedAt ? moment.utc(msg.updatedAt).valueOf() : undefined
     };
-    return result;
-  }
-}
 
-module.exports = Transformer;
+    return utils.dropNullAndUndefinedObject(result);
+  },
+
+  /** @function transaction
+   *  @description Transforms a Trxn model from the db into TransactionResponse API object
+   *
+   *  @param {object} trxn - a Trxn model object
+   *  @returns TransactionResponse
+   *  @see Trxn
+   */
+  toTransactionResponse: trxn => {
+    const result = {
+      messages: trxn.messages.map(m => {
+        return {
+          msgId: m.messageId,
+          to: m.email.to
+        };
+      }),
+      txId: trxn.transactionId
+    };
+
+    return result;
+  },
+};
+
+module.exports = transformer;

--- a/app/src/components/utils.js
+++ b/app/src/components/utils.js
@@ -24,16 +24,16 @@ const utils = {
    */
   calculateDelayTS: (delay, timestamp) => timestamp + delay,
 
-  /** @function dropNullAndUndefinedObject
-   *  @description Recursively removes any null or undefined properties in an object
+  /** @function dropUndefinedObject
+   *  @description Recursively removes any undefined properties in an object
    *
    *  @param {object} obj - The object to operate on
-   *  @returns {object} The object `obj` without null and undefined properties
+   *  @returns {object} The object `obj` without undefined properties
    */
-  dropNullAndUndefinedObject: obj => {
-    Object.entries(obj).forEach(([key, val]) => {
-      if (val && typeof val === 'object') utils.dropNullAndUndefinedObject(val);
-      else if (val == null) delete obj[key];
+  dropUndefinedObject: obj => {
+    Object.keys(obj).forEach(key => {
+      if (obj[key] && typeof obj[key] === 'object') utils.dropUndefinedObject(obj[key]);
+      else if (obj[key] === undefined) delete obj[key];
     });
     return obj;
   },

--- a/app/src/components/utils.js
+++ b/app/src/components/utils.js
@@ -1,23 +1,48 @@
+/**
+ * @module utils
+ *
+ * @description A utilities component with useful functions
+ *
+ * @exports utils
+ */
 const utils = {
-  /** Calculates the difference in delay relative to now
+  /** @function calculateDelayMS
+   *  @description Calculates the difference in delay relative to now
+   *
    *  @param {integer} delayTS Desired UTC time to delay to
    *  @returns {integer} Number of milliseconds `delayTS` is in the future
    *    If `delayTS` is now or in the past, it will return 0
    */
   calculateDelayMS: delayTS => Math.max(delayTS - Date.now(), 0),
 
-  /** Calculates the delay relative to a provided timestamp
+  /** @function calculateDelayTS
+   *  @description Calculates the delay relative to a provided timestamp
+   *
    *  @param {integer} delay Number of milliseconds to delay
    *  @param {integer} timestamp Reference UTC time
    *  @returns {integer} A UTC time with the delay added
    */
   calculateDelayTS: (delay, timestamp) => timestamp + delay,
 
-  /** Returns a new object where undefined and empty arrays are dropped
+  /** @function dropNullAndUndefinedObject
+   *  @description Recursively removes any null or undefined properties in an object
+   *
+   *  @param {object} obj - The object to operate on
+   *  @returns {object} The object `obj` without null and undefined properties
+   */
+  dropNullAndUndefinedObject: obj => {
+    return Object.entries(obj).reduce((acc, [k, v]) => (
+      v == null ? acc : { ...acc, [k]: (typeof v === 'object' ? utils.dropNullAndUndefinedObject(v) : v) }
+    ), {});
+  },
+
+  /** @function filterUndefinedAndEmptyArray
+   *  @description Returns a new object where undefined and empty arrays are dropped
+   *
    *  @param {object} obj A JSON Object
    *  @returns {object} A JSON Object without empty arrays and undefined properties
    */
-  filterUndefinedAndEmpty: obj => {
+  filterUndefinedAndEmptyArray: obj => {
     const ret = {};
     Object.keys(obj)
       .filter((key) => obj[key] !== undefined && obj[key].length)
@@ -25,21 +50,26 @@ const utils = {
     return ret;
   },
 
-  /** Returns a pretty JSON representation of an object
+  /** @function prettyStringify
+   *  @description Returns a pretty JSON representation of an object
+   *
    *  @param {object} obj A JSON Object
    *  @param {integer} indent Number of spaces to indent
    *  @returns {string} A pretty printed string representation of `obj` with `indent` indentation
    */
   prettyStringify: (obj, indent = 2) => JSON.stringify(obj, null, indent),
 
-  /** Returns a string in Pascal Case
+  /** @function toPascalCase
+   *  @description Returns a string in Pascal Case
+   *
    *  @param {string} str A string
    *  @returns {string} A string formatted in Pascal Case
    */
   toPascalCase: str => str.toLowerCase().replace(/\b\w/g, t => t.toUpperCase()),
 
-  /** A blocking sleep/wait function
-   *  https://stackoverflow.com/a/39914235
+  /** @function wait
+   *  @description A blocking sleep/wait function - https://stackoverflow.com/a/39914235
+   *
    *  @param {integer} ms Number of milliseconds to wait
    *  @returns A promise after `ms` milliseconds
    */

--- a/app/src/components/utils.js
+++ b/app/src/components/utils.js
@@ -31,9 +31,11 @@ const utils = {
    *  @returns {object} The object `obj` without null and undefined properties
    */
   dropNullAndUndefinedObject: obj => {
-    return Object.entries(obj).reduce((acc, [k, v]) => (
-      v == null ? acc : { ...acc, [k]: (typeof v === 'object' ? utils.dropNullAndUndefinedObject(v) : v) }
-    ), {});
+    Object.entries(obj).forEach(([key, val]) => {
+      if (val && typeof val === 'object') utils.dropNullAndUndefinedObject(val);
+      else if (val == null) delete obj[key];
+    });
+    return obj;
   },
 
   /** @function filterUndefinedAndEmptyArray

--- a/app/src/components/validators.js
+++ b/app/src/components/validators.js
@@ -362,6 +362,16 @@ const validators = {
     }
   },
 
+  statusFetch: param => {
+    const errors = [];
+
+    if (!validators.queryParams.msgId(param.msgId)) {
+      errors.push({ value: param.msgId, message: 'Invalid value `msgId`.' });
+    }
+
+    return errors;
+  },
+
   statusQuery: query => {
     const errors = [];
 

--- a/app/src/components/validators.js
+++ b/app/src/components/validators.js
@@ -382,7 +382,7 @@ const validators = {
       });
     }
 
-    errors.concat(validators.statusQueryFields(query));
+    validators.statusQueryFields(query).forEach(error => errors.push(error));
 
     if (query && query.fields) {
       query.fields.split(',').forEach(field => {

--- a/app/src/components/validators.js
+++ b/app/src/components/validators.js
@@ -325,6 +325,32 @@ const validators = {
       return validatorUtils.isEmailList(value) && value.length > 0;
     }
 
+  },
+
+  statusQuery: query => {
+    const errors = [];
+
+    const checkValidQuery = element => ['msgId', 'status', 'tag', 'txId'].includes(element);
+    if (!query || !Object.keys(query).some(checkValidQuery)) {
+      errors.push({
+        value: 'params',
+        message: 'At least one of `msgId`, `status`, `tag` or `txId` must be defined.'
+      });
+    }
+
+    const hasValidField = element => ['createdTimestamp', 'delayTS', 'updatedTimestamp'].includes(element);
+    if (!query && query.fields) {
+      query.fields.split(',').forEach(field => {
+        if (!hasValidField(field)) {
+          errors.push({
+            value: 'fields',
+            message: `Value "${field}" is not one of \`createdTimestamp\`, \`delayTS\`, or \`updatedTimestamp\`.`
+          });
+        }
+      });
+    }
+
+    return errors;
   }
 
 };

--- a/app/src/components/validators.js
+++ b/app/src/components/validators.js
@@ -382,10 +382,7 @@ const validators = {
       });
     }
 
-    const queryErrors = validators.statusQueryFields(query, errors);
-    if (queryErrors) {
-      queryErrors.forEach(x => errors.push(x));
-    }
+    errors.concat(validators.statusQueryFields(query));
 
     if (query && query.fields) {
       query.fields.split(',').forEach(field => {
@@ -401,7 +398,9 @@ const validators = {
     return errors;
   },
 
-  statusQueryFields: (obj, errors) => {
+  statusQueryFields: obj => {
+    const errors = [];
+
     if (!validators.queryParams.msgId(obj.msgId)) {
       errors.push({ value: obj.msgId, message: 'Invalid value `msgId`.' });
     }
@@ -414,6 +413,8 @@ const validators = {
     if (!validators.queryParams.txId(obj.txId)) {
       errors.push({ value: obj.txId, message: 'Invalid value `txId`.' });
     }
+
+    return errors;
   },
 
 };
@@ -444,13 +445,7 @@ const validatorUtils = {
   /** @function isString */
   isString: x => {
     return Object.prototype.toString.call(x) === '[object String]';
-  },
-
-  /** @function isValidUUIDString */
-  isUUIDString: uuid => {
-    const pattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-5][0-9a-f]{3}-[089ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
-    return pattern.test(uuid);
-  },
+  }
 };
 
 module.exports = { validators, validatorUtils };

--- a/app/src/components/validators.js
+++ b/app/src/components/validators.js
@@ -331,7 +331,7 @@ const validators = {
     /** @function msgId */
     msgId: value => {
       if (value) {
-        return validator.isUUID(value);
+        return validatorUtils.isString(value) && validator.isUUID(value);
       }
       return true;
     },
@@ -356,7 +356,7 @@ const validators = {
     /** @function txId */
     txId: value => {
       if (value) {
-        return validator.isUUID(value);
+        return validatorUtils.isString(value) && validator.isUUID(value);
       }
       return true;
     }

--- a/app/src/docs/v1.api-spec.yaml
+++ b/app/src/docs/v1.api-spec.yaml
@@ -179,8 +179,9 @@ paths:
       description: >-
         This is a freeform query endpoint, and reasonably expects at least one
         of the parameters to be populated. To minimize response size, only
-        msgId, status, tag and txId properties will appear if no other fields
-        are explicitly requested.
+        msgId, status, tag and txId properties appear by default. Properties
+        createdTimestamp, delayTS and updatedTimestamp may be requested. The
+        statusHistory property will not appear from this specific endpoint.
       operationId: GetStatusQuery
       tags:
         - Message
@@ -250,6 +251,10 @@ paths:
   /cancel:
     delete:
       summary: Cancel multiple delayed messages
+      description: >-
+        This endpoint searches for and will cancel and terminate a set of
+        messages that are still in an enqueued/delayed state. Messages cannot be
+        cancelled once they are beyond the processing state.
       operationId: DeleteCancelQuery
       tags:
         - Message
@@ -287,6 +292,10 @@ paths:
   '/cancel/{msgId}':
     delete:
       summary: Cancel a single delayed message
+      description: >-
+        This endpoint will cancel and terminate the specified msgId if the
+        message is still in an enqueued/delayed state. Messages cannot be
+        cancelled once they are beyond the processing state.
       operationId: DeleteCancelMessage
       tags:
         - Message
@@ -341,9 +350,8 @@ components:
         enum:
           - createdTimestamp
           - delayTS
-          - statusHistory
           - updatedTimestamp
-      example: 'delayTS,statusHistory'
+      example: 'delayTS,updatedTimestamp'
     QueryMessageId:
       in: query
       name: msgId
@@ -735,6 +743,24 @@ components:
         detail:
           type: string
           description: Short description of why this problem was raised.
+    StatusHistoryObject:
+      type: array
+      description: A list of status changes to this message
+      items:
+        type: object
+        required:
+          - description
+          - status
+          - timestamp
+        properties:
+          description:
+            type: string
+            description: The status message description if applicable
+          status:
+            $ref: '#/components/schemas/StatusType'
+          timestamp:
+            type: integer
+            description: The moment in time this log event occured
     StatusObject:
       type: object
       required:
@@ -759,19 +785,7 @@ components:
         status:
           $ref: '#/components/schemas/StatusType'
         statusHistory:
-          type: array
-          description: A list of status changes to this message
-          items:
-            type: object
-            properties:
-              description:
-                type: string
-                description: The status message description if applicable
-              status:
-                $ref: '#/components/schemas/StatusType'
-              timestamp:
-                type: integer
-                description: The moment in time this log event occured
+          $ref: '#/components/schemas/StatusHistoryObject'
         tag:
           type: string
           description: A unique string which is associated with the message

--- a/app/src/docs/v1.api-spec.yaml
+++ b/app/src/docs/v1.api-spec.yaml
@@ -178,10 +178,8 @@ paths:
       summary: Queryable message transaction status
       description: >-
         This is a freeform query endpoint, and reasonably expects at least one
-        of the parameters to be populated. To minimize response size, only
-        msgId, status, tag and txId properties appear by default. Properties
-        createdTimestamp, delayTS and updatedTimestamp may be requested. The
-        statusHistory property will not appear from this specific endpoint.
+        of the parameters to be populated. The statusHistory property will not
+        appear from this specific endpoint.
       operationId: GetStatusQuery
       tags:
         - Message
@@ -189,7 +187,6 @@ paths:
         - OpenID:
             - EMAILER
       parameters:
-        - $ref: '#/components/parameters/QueryFields'
         - $ref: '#/components/parameters/QueryMessageId'
         - $ref: '#/components/parameters/QueryStatus'
         - $ref: '#/components/parameters/QueryTag'
@@ -343,19 +340,6 @@ components:
         type: string
         format: uuid
         example: 00000000-0000-0000-0000-000000000000
-    QueryFields:
-      in: query
-      name: fields
-      description: >-
-        Explicitly request for additional data fields related to the messages.
-        Entries should be comma separated.
-      schema:
-        type: string
-        enum:
-          - createdTimestamp
-          - delayTS
-          - updatedTimestamp
-      example: 'delayTS,updatedTimestamp'
     QueryMessageId:
       in: query
       name: msgId
@@ -481,7 +465,9 @@ components:
             someone: user
         delayTS:
           type: integer
-          description: Desired UTC time for sending the message
+          description: >-
+            Desired UTC time for sending the message. 0 = Queue to send
+            immediately
           example: 1570000000
         tag:
           type: string
@@ -670,7 +656,9 @@ components:
             - bar@gov.bc.ca
         delayTS:
           type: integer
-          description: Desired UTC time for sending the message
+          description: >-
+            Desired UTC time for sending the message. 0 = Queue to send
+            immediately
           example: 1570000000
         encoding:
           type: string
@@ -768,18 +756,23 @@ components:
     StatusObject:
       type: object
       required:
+        - createdTS
+        - delayTS
         - msgId
         - status
         - tag
         - txId
+        - updatedTS
       properties:
-        createdTimestamp:
+        createdTS:
           type: integer
           description: UTC time this service first received this message queue request
           example: 1560000000
         delayTS:
           type: integer
-          description: Desired UTC time for sending the message
+          description: >-
+            Desired UTC time for sending the message. 0 = Queue to send
+            immediately
           example: 1570000000
         msgId:
           type: string
@@ -799,7 +792,7 @@ components:
           description: The associated transaction uuid
           format: uuid
           example: 00000000-0000-0000-0000-000000000000
-        updatedTimestamp:
+        updatedTS:
           type: integer
           description: UTC time this message queue request was last updated
           example: 1570000000

--- a/app/src/docs/v1.api-spec.yaml
+++ b/app/src/docs/v1.api-spec.yaml
@@ -244,6 +244,8 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '404':
           $ref: '#/components/responses/NotFound'
+        '422':
+          $ref: '#/components/responses/UnprocessableEntity'
         default:
           description: Unexpected error
           content:

--- a/app/src/docs/v1.api-spec.yaml
+++ b/app/src/docs/v1.api-spec.yaml
@@ -178,8 +178,8 @@ paths:
       summary: Queryable message transaction status
       description: >-
         This is a freeform query endpoint, and reasonably expects at least one
-        of the parameters to be populated. The statusHistory property will not
-        appear from this specific endpoint.
+        of the parameters to be populated. The statusHistory property will
+        always be an empty array from this specific endpoint.
       operationId: GetStatusQuery
       tags:
         - Message
@@ -760,6 +760,7 @@ components:
         - delayTS
         - msgId
         - status
+        - statusHistory
         - tag
         - txId
         - updatedTS

--- a/app/src/docs/v1.api-spec.yaml
+++ b/app/src/docs/v1.api-spec.yaml
@@ -208,6 +208,8 @@ paths:
           $ref: '#/components/responses/UnauthorizedError'
         '403':
           $ref: '#/components/responses/Forbidden'
+        '422':
+          $ref: '#/components/responses/UnprocessableEntity'
         default:
           description: Unexpected error
           content:

--- a/app/src/middleware/validation.js
+++ b/app/src/middleware/validation.js
@@ -24,9 +24,14 @@ const validateMerge = async (req, res, next) => {
 
 };
 
+const validateStatusFetch = (req, res, next) => {
+  const errors = validators.statusFetch(req.params);
+  handleValidationErrors(res, next, errors);
+}
+
 const validateStatusQuery = (req, res, next) => {
   const errors = validators.statusQuery(req.query);
   handleValidationErrors(res, next, errors);
 };
 
-module.exports = { validateEmail, validateMerge, validateStatusQuery };
+module.exports = { validateEmail, validateMerge, validateStatusFetch, validateStatusQuery };

--- a/app/src/middleware/validation.js
+++ b/app/src/middleware/validation.js
@@ -2,26 +2,31 @@ const config = require('config');
 const Problem = require('api-problem');
 const { validators } = require('../components/validators');
 
-const validateEmail = async (req, res, next) => {
-  const errors = await validators.email(req.body, config.get('server.attachmentLimit'));
-  if (errors.length > 0) {
+const handleValidationErrors = (res, next, errors) => {
+  if (errors && errors.length) {
     return new Problem(422, {
       detail: 'Validation failed',
       errors: errors
     }).send(res);
   }
+
   next();
+};
+
+const validateEmail = async (req, res, next) => {
+  const errors = await validators.email(req.body, config.get('server.attachmentLimit'));
+  handleValidationErrors(res, next, errors);
 };
 
 const validateMerge = async (req, res, next) => {
   const errors = await validators.merge(req.body, config.get('server.attachmentLimit'));
-  if (errors.length > 0) {
-    return new Problem(422, {
-      detail: 'Validation failed',
-      errors: errors
-    }).send(res);
-  }
-  next();
+  handleValidationErrors(res, next, errors);
+
 };
 
-module.exports = { validateEmail, validateMerge };
+const validateStatusQuery = (req, res, next) => {
+  const errors = validators.statusQuery(req.query);
+  handleValidationErrors(res, next, errors);
+};
+
+module.exports = { validateEmail, validateMerge, validateStatusQuery };

--- a/app/src/middleware/validation.js
+++ b/app/src/middleware/validation.js
@@ -27,7 +27,7 @@ const validateMerge = async (req, res, next) => {
 const validateStatusFetch = (req, res, next) => {
   const errors = validators.statusFetch(req.params);
   handleValidationErrors(res, next, errors);
-}
+};
 
 const validateStatusQuery = (req, res, next) => {
   const errors = validators.statusQuery(req.query);

--- a/app/src/routes/v1/email.js
+++ b/app/src/routes/v1/email.js
@@ -1,14 +1,15 @@
 const emailRouter = require('express').Router();
 const { validateEmail } = require('../../middleware/validation');
-
 const ChesService = require('../../services/chesSvc');
+
+const chesService = new ChesService();
 
 /** Email sending endpoint */
 emailRouter.post('/', validateEmail, async (req, res, next) => {
   try {
     const ethereal = (req.query.devMode !== undefined);
 
-    const chesService = new ChesService();
+
     const result = await chesService.sendEmail(req.authorizedParty, req.body, ethereal);
     res.status(201).json(result);
   } catch (error) {

--- a/app/src/routes/v1/email.js
+++ b/app/src/routes/v1/email.js
@@ -9,7 +9,6 @@ emailRouter.post('/', validateEmail, async (req, res, next) => {
   try {
     const ethereal = (req.query.devMode !== undefined);
 
-
     const result = await chesService.sendEmail(req.authorizedParty, req.body, ethereal);
     res.status(201).json(result);
   } catch (error) {

--- a/app/src/routes/v1/merge.js
+++ b/app/src/routes/v1/merge.js
@@ -4,12 +4,13 @@ const mergeRouter = require('express').Router();
 const { validateMerge } = require('../../middleware/validation');
 const ChesService = require('../../services/chesSvc');
 
+const chesService = new ChesService();
+
 /** Template mail merge & email sending endpoint */
 mergeRouter.post('/', validateMerge, async (req, res, next) => {
   try {
     const ethereal = (req.query.devMode !== undefined);
 
-    const chesService = new ChesService();
     const result = await chesService.sendEmailMerge(req.authorizedParty, req.body, ethereal);
     res.status(201).json(result);
   } catch (error) {

--- a/app/src/routes/v1/merge.js
+++ b/app/src/routes/v1/merge.js
@@ -2,7 +2,6 @@ const mergeComponent = require('../../components/merge');
 
 const mergeRouter = require('express').Router();
 const { validateMerge } = require('../../middleware/validation');
-
 const ChesService = require('../../services/chesSvc');
 
 /** Template mail merge & email sending endpoint */

--- a/app/src/routes/v1/status.js
+++ b/app/src/routes/v1/status.js
@@ -1,11 +1,25 @@
 const ChesService = require('../../services/chesSvc');
+const { validateStatusQuery } = require('../../middleware/validation');
 
 const statusRouter = require('express').Router();
+const chesService = new ChesService();
+
+statusRouter.get('/', validateStatusQuery, async (req, res, next) => {
+  try {
+    const { fields, ...params } = req.query;
+
+    // Return
+    res.status(200).json({
+      fields: fields,
+      params: params
+    });
+  } catch (err) {
+    next(err);
+  }
+});
 
 statusRouter.get('/:msgId', async (req, res, next) => {
   try {
-    const chesService = new ChesService();
-
     // transform message and statuses into API format...
     const status = await chesService.getStatus(req.authorizedParty, req.params.msgId);
 

--- a/app/src/routes/v1/status.js
+++ b/app/src/routes/v1/status.js
@@ -6,10 +6,9 @@ const chesService = new ChesService();
 
 statusRouter.get('/', validateStatusQuery, async (req, res, next) => {
   try {
-    const { fields, ...params } = req.query;
-
     // Find messages, transform message and statuses into API format
-    const status = await chesService.findStatuses(req.authorizedParty, params, fields);
+    const status = await chesService.findStatuses(req.authorizedParty, req.params.msgId,
+      req.params.status, req.query.tag, req.query.txId, req.query.fields);
 
     // Return
     res.status(200).json(status);

--- a/app/src/routes/v1/status.js
+++ b/app/src/routes/v1/status.js
@@ -7,8 +7,8 @@ const chesService = new ChesService();
 statusRouter.get('/', validateStatusQuery, async (req, res, next) => {
   try {
     // Find messages, transform message and statuses into API format
-    const status = await chesService.findStatuses(req.authorizedParty, req.params.msgId,
-      req.params.status, req.query.tag, req.query.txId, req.query.fields);
+    const status = await chesService.findStatuses(req.authorizedParty, req.query.msgId,
+      req.query.status, req.query.tag, req.query.txId, req.query.fields);
 
     // Return
     res.status(200).json(status);

--- a/app/src/routes/v1/status.js
+++ b/app/src/routes/v1/status.js
@@ -1,5 +1,5 @@
 const ChesService = require('../../services/chesSvc');
-const { validateStatusQuery } = require('../../middleware/validation');
+const { validateStatusFetch, validateStatusQuery } = require('../../middleware/validation');
 
 const statusRouter = require('express').Router();
 const chesService = new ChesService();
@@ -17,7 +17,7 @@ statusRouter.get('/', validateStatusQuery, async (req, res, next) => {
   }
 });
 
-statusRouter.get('/:msgId', async (req, res, next) => {
+statusRouter.get('/:msgId', validateStatusFetch, async (req, res, next) => {
   try {
     // transform message and statuses into API format...
     const status = await chesService.getStatus(req.authorizedParty, req.params.msgId);

--- a/app/src/routes/v1/status.js
+++ b/app/src/routes/v1/status.js
@@ -8,7 +8,7 @@ statusRouter.get('/', validateStatusQuery, async (req, res, next) => {
   try {
     // Find messages, transform message and statuses into API format
     const status = await chesService.findStatuses(req.authorizedParty, req.query.msgId,
-      req.query.status, req.query.tag, req.query.txId, req.query.fields);
+      req.query.status, req.query.tag, req.query.txId);
 
     // Return
     res.status(200).json(status);

--- a/app/src/routes/v1/status.js
+++ b/app/src/routes/v1/status.js
@@ -8,11 +8,11 @@ statusRouter.get('/', validateStatusQuery, async (req, res, next) => {
   try {
     const { fields, ...params } = req.query;
 
+    // Find messages, transform message and statuses into API format
+    const status = await chesService.findStatuses(req.authorizedParty, params, fields);
+
     // Return
-    res.status(200).json({
-      fields: fields,
-      params: params
-    });
+    res.status(200).json(status);
   } catch (err) {
     next(err);
   }

--- a/app/src/routes/v1/status.js
+++ b/app/src/routes/v1/status.js
@@ -1,7 +1,7 @@
-const ChesService = require('../../services/chesSvc');
-const { validateStatusFetch, validateStatusQuery } = require('../../middleware/validation');
-
 const statusRouter = require('express').Router();
+const { validateStatusFetch, validateStatusQuery } = require('../../middleware/validation');
+const ChesService = require('../../services/chesSvc');
+
 const chesService = new ChesService();
 
 statusRouter.get('/', validateStatusQuery, async (req, res, next) => {

--- a/app/src/services/chesSvc.js
+++ b/app/src/services/chesSvc.js
@@ -82,7 +82,7 @@ class ChesService {
     this._queueService = v;
   }
 
-  async findStatuses(client, query, fields) {
+  async findStatuses(client, msgId, status, tag, txId, fields) {
     let fieldArray;
     if (fields) {
       fieldArray = fields.split(',')
@@ -97,7 +97,7 @@ class ChesService {
         .filter(field => field != null);
     }
 
-    return await this.dataService.findMessagesByQuery(client, query.msgId, query.status, query.tag, query.txId, fieldArray);
+    return await this.dataService.findMessagesByQuery(client, msgId, status, tag, txId, fieldArray);
   }
 
   async getStatus(client, messageId) {

--- a/app/src/services/chesSvc.js
+++ b/app/src/services/chesSvc.js
@@ -18,12 +18,12 @@ const { NotFoundError } = require('objection');
 const Problem = require('api-problem');
 
 const mergeComponent = require('../components/merge');
+const transformer = require('../components/transformer');
 const utils = require('../components/utils');
 
 const DataService = require('./dataSvc');
 const EmailService = require('./emailSvc');
 const QueueService = require('./queueSvc');
-const Transformer = require('./transform');
 
 class ChesService {
 
@@ -111,7 +111,7 @@ class ChesService {
 
     try {
       const result = await this.dataService.findMessagesByQuery(client, messageId, status, tag, transactionId, fieldArray);
-      return result.map(msg => Transformer.status(msg));
+      return result.map(msg => transformer.toStatusResponse(msg));
     } catch (e) {
       if (e instanceof NotFoundError) {
         log.verbose('findStatuses', 'No messages found');
@@ -141,7 +141,7 @@ class ChesService {
       const msg = await this.dataService.readMessage(client, messageId);
 
       // transform message and statuses into API format...
-      const status = Transformer.status(msg);
+      const status = transformer.toStatusResponse(msg);
       return status;
     } catch (e) {
       if (e instanceof NotFoundError) {
@@ -187,7 +187,7 @@ class ChesService {
         trxn = await this.dataService.readTransaction(client, trxn.transactionId);
 
         //return to caller in API format
-        return Transformer.transaction(trxn);
+        return transformer.toTransactionResponse(trxn);
       }
     } catch (e) {
       log.error(`Send Email error. ${e.message}`);
@@ -241,7 +241,7 @@ class ChesService {
         trxn = await this.dataService.readTransaction(client, trxn.transactionId);
 
         // return transaction in API format
-        return Transformer.transaction(trxn);
+        return transformer.toTransactionResponse(trxn);
       }
     } catch (e) {
       log.error(`Send Email Merge error. ${e.message}`);

--- a/app/src/services/chesSvc.js
+++ b/app/src/services/chesSvc.js
@@ -31,7 +31,7 @@ class ChesService {
    * Creates a new ChesService with default Data, Email, Queue Services (all with default connections).
    * @class
    */
-  constructor () {
+  constructor() {
     this.dataService = new DataService();
     this.emailService = new EmailService();
     this.queueService = new QueueService();
@@ -40,7 +40,7 @@ class ChesService {
   /** @function dataService
    *  Gets the current DataService
    */
-  get dataService () {
+  get dataService() {
     return this._dataService;
   }
 
@@ -48,14 +48,14 @@ class ChesService {
    *  Sets the current DataService
    *  @param {object} v - a DataService object.
    */
-  set dataService (v) {
+  set dataService(v) {
     this._dataService = v;
   }
 
   /** @function emailService
    *  Gets the current EmailService
    */
-  get emailService () {
+  get emailService() {
     return this._emailService;
   }
 
@@ -63,14 +63,14 @@ class ChesService {
    *  Sets the current EmailService
    *  @param {object} v - am EmailService object.
    */
-  set emailService (v) {
+  set emailService(v) {
     this._emailService = v;
   }
 
   /** @function queueService
    *  Gets the current QueueService
    */
-  get queueService () {
+  get queueService() {
     return this._queueService;
   }
 
@@ -78,11 +78,29 @@ class ChesService {
    *  Sets the current QueueService
    *  @param {object} v - a QueueService.
    */
-  set queueService (v) {
+  set queueService(v) {
     this._queueService = v;
   }
 
-  async getStatus (client, messageId) {
+  async findStatuses(client, query, fields) {
+    let fieldArray;
+    if (fields) {
+      fieldArray = fields.split(',')
+        .map(field => {
+          switch (field) {
+            case 'createdTimestamp': return 'createdAt';
+            case 'delayTS': return 'delayTimestamp';
+            case 'updatedTimestamp': return 'updatedAt';
+            default: return;
+          }
+        })
+        .filter(field => field != null);
+    }
+
+    return await this.dataService.findMessagesByQuery(client, query.msgId, query.status, query.tag, query.txId, fieldArray);
+  }
+
+  async getStatus(client, messageId) {
     if (!messageId) {
       throw new Problem(400, { detail: 'Error getting status. Message Id cannot be null' });
     }
@@ -113,7 +131,7 @@ class ChesService {
    *  @param {boolean} ethereal - if true, then use the Ethereal connection, send email immediately.
    *  @returns {object} TransactionResponse
    */
-  async sendEmail (client, message, ethereal = false) {
+  async sendEmail(client, message, ethereal = false) {
     if (!message) {
       throw new Problem(400, { detail: 'Error sending email. Email message cannot be null' });
     }
@@ -154,7 +172,7 @@ class ChesService {
    *  @param {boolean} ethereal - if true, then use the Ethereal connection, send email immediately.
    *  @returns {object} TransactionResponse
    */
-  async sendEmailMerge (client, template, ethereal = false) {
+  async sendEmailMerge(client, template, ethereal = false) {
     if (!template) {
       throw new Problem(400, { detail: 'Error sending email merge. Email templates/contexts cannot be null' });
     }

--- a/app/src/services/chesSvc.js
+++ b/app/src/services/chesSvc.js
@@ -97,7 +97,8 @@ class ChesService {
         .filter(field => field != null);
     }
 
-    return await this.dataService.findMessagesByQuery(client, msgId, status, tag, txId, fieldArray);
+    const result = await this.dataService.findMessagesByQuery(client, msgId, status, tag, txId, fieldArray);
+    return result.map(msg => Transformer.status(msg));
   }
 
   async getStatus(client, messageId) {

--- a/app/src/services/chesSvc.js
+++ b/app/src/services/chesSvc.js
@@ -90,27 +90,12 @@ class ChesService {
    *  @param {string} status - the desired status of the messages
    *  @param {string} tag - the desired tag of the messages
    *  @param {string} transactionId - the id of the desired transaction
-   *  @param {string} fields - a comma separated list of desired columns in addition to the defaults
    *  @throws Problem if an unexpected error occurs
    *  @returns {object[]} Array of Status objects with a subset of properties
    */
-  async findStatuses(client, messageId, status, tag, transactionId, fields) {
-    let fieldArray;
-    if (fields) {
-      fieldArray = fields.split(',')
-        .map(field => {
-          switch (field) {
-            case 'createdTimestamp': return 'createdAt';
-            case 'delayTS': return 'delayTimestamp';
-            case 'updatedTimestamp': return 'updatedAt';
-            default: return;
-          }
-        })
-        .filter(field => field != null);
-    }
-
+  async findStatuses(client, messageId, status, tag, transactionId) {
     try {
-      const result = await this.dataService.findMessagesByQuery(client, messageId, status, tag, transactionId, fieldArray);
+      const result = await this.dataService.findMessagesByQuery(client, messageId, status, tag, transactionId);
       return result.map(msg => transformer.toStatusResponse(msg));
     } catch (e) {
       if (e instanceof NotFoundError) {

--- a/app/src/services/dataSvc.js
+++ b/app/src/services/dataSvc.js
@@ -189,8 +189,8 @@ class DataService {
     return Message.query()
       .column(columns)
       .whereIn('transactionId', trxnQuery)
-      .andWhere(parameters)
-      .throwIfNotFound();
+      .andWhere(parameters);
+    // .throwIfNotFound();
   }
 
   /** @function readMessage

--- a/app/src/services/dataSvc.js
+++ b/app/src/services/dataSvc.js
@@ -189,8 +189,8 @@ class DataService {
     return Message.query()
       .column(columns)
       .whereIn('transactionId', trxnQuery)
-      .andWhere(parameters);
-    // .throwIfNotFound();
+      .andWhere(parameters)
+      .throwIfNotFound();
   }
 
   /** @function readMessage

--- a/app/src/services/dataSvc.js
+++ b/app/src/services/dataSvc.js
@@ -170,7 +170,7 @@ class DataService {
    *  @returns {object[]} Array of Message objects with a subset of properties
    */
   async findMessagesByQuery(client, messageId, status, tag, transactionId, fields = []) {
-    const parameters = utils.dropNullAndUndefinedObject({
+    const parameters = utils.dropUndefinedObject({
       messageId: messageId,
       status: status,
       tag: tag,

--- a/app/src/services/emailSvc.js
+++ b/app/src/services/emailSvc.js
@@ -45,7 +45,7 @@ class EmailService {
    *  @returns {object} - the nodemailer message
    */
   createEnvelope (message) {
-    const envelope = utils.filterUndefinedAndEmpty(message);
+    const envelope = utils.filterUndefinedAndEmptyArray(message);
     // Reassign the body field into the type specified by bodyType
     delete Object.assign(envelope, {
       [message.bodyType]: envelope['body']

--- a/app/src/services/transform.js
+++ b/app/src/services/transform.js
@@ -28,29 +28,28 @@ class Transformer {
   }
 
   /** @function status
-   *  @description Transforms a Message model from the db into StatusResponse for the api
+   *  @description Transforms a Message model from the db into a StatusResponse API object
    *
-   *  @param {object} msg - a Fully inflated Message
-   *  @returns StatusResponse
+   *  @param {object} msg - a Message model object
+   *  @returns {object} StatusResponse
    *  @see Message
    */
   static status(msg) {
-    const delayTS = msg.delayTimestamp ? moment.utc(Number(msg.delayTimestamp)).valueOf() : null;
     const result = {
-      createdTimestamp: moment.utc(msg.createdAt).valueOf(),
-      delayTS: delayTS,
-      msgId: msg.messageId,
-      status: msg.status,
-      statusHistory: msg.statusHistory.map(h => {
+      createdTimestamp: msg.createdAt ? moment.utc(msg.createdAt).valueOf() : undefined,
+      delayTS: msg.delayTimestamp ? moment.utc(Number(msg.delayTimestamp)).valueOf() : undefined,
+      msgId: msg.messageId ? msg.messageId : undefined,
+      status: msg.status ? msg.status : undefined,
+      statusHistory: msg.statusHistory ? msg.statusHistory.map(h => {
         return {
           description: h.description,
           status: h.status,
           timestamp: moment.utc(h.createdAt).valueOf()
         };
-      }),
-      tag: msg.tag,
-      txId: msg.transactionId,
-      updatedTimestamp: moment.utc(msg.updatedAt).valueOf()
+      }) : undefined,
+      tag: msg.tag ? msg.tag : undefined,
+      txId: msg.transactionId ? msg.transactionId : undefined,
+      updatedTimestamp: msg.updatedAt ? moment.utc(msg.updatedAt).valueOf() : undefined
     };
     return result;
   }

--- a/app/src/services/transform.js
+++ b/app/src/services/transform.js
@@ -9,6 +9,7 @@ class Transformer {
 
   /** @function transaction
    *  @description Transforms a Trxn model from the db into TransactionResponse for the api
+   *
    *  @param {object} trxn - a Fully inflated Trxn
    *  @returns TransactionResponse
    *  @see Trxn
@@ -28,6 +29,7 @@ class Transformer {
 
   /** @function status
    *  @description Transforms a Message model from the db into StatusResponse for the api
+   *
    *  @param {object} msg - a Fully inflated Message
    *  @returns StatusResponse
    *  @see Message

--- a/app/tests/integration/chesSvc.spec.js
+++ b/app/tests/integration/chesSvc.spec.js
@@ -198,9 +198,8 @@ describe('ches service', () => {
 
       expect(result).toBeTruthy();
       expect(result.msgId).toMatch(trxn.messages[0].messageId);
-      expect(result.statuses).toBeTruthy();
-      expect(result.statuses).toHaveLength(1);
-
+      expect(result.statusHistory).toBeTruthy();
+      expect(result.statusHistory).toHaveLength(1);
     });
 
   });

--- a/app/tests/unit/components/health.spec.js
+++ b/app/tests/unit/components/health.spec.js
@@ -3,28 +3,49 @@ const health = require('../../../src/components/health');
 
 helper.logHelper();
 
+let mockConnFn = jest.fn();
 jest.mock('../../../src/services/emailConn', () => {
-  return jest.fn().mockImplementation(() => {
+  return jest.fn(() => {
     return {
-      checkConnection: async () => {
-        return true;
-      },
+      checkConnection: mockConnFn,
       host: 'https://thehost.ca'
     };
   });
 });
 
 describe('getSmtpStatus', () => {
+  afterEach(() => {
+    mockConnFn.mockClear();
+  });
 
   it('should return host on valid connection', async () => {
+    mockConnFn.mockImplementation(async () => {
+      return true;
+    });
 
     const result = await health.getSmtpStatus();
+
     expect(result).toBeTruthy();
     expect(result.name).toMatch('SMTP Endpoint');
     expect(result.endpoint).toMatch('https://thehost.ca');
     expect(result.authenticated).toBeTruthy();
     expect(result.authorized).toBeTruthy();
     expect(result.healthCheck).toBeTruthy();
+  });
+
+  it('should log an error if there is a failure', async () => {
+    mockConnFn.mockImplementation(async () => {
+      throw new Error('bad');
+    });
+
+    const result = await health.getSmtpStatus();
+
+    expect(result).toBeTruthy();
+    expect(result.name).toMatch('SMTP Endpoint');
+    expect(result.endpoint).toMatch('https://thehost.ca');
+    expect(result.authenticated).toBeFalsy();
+    expect(result.authorized).toBeFalsy();
+    expect(result.healthCheck).toBeFalsy();
   });
 });
 
@@ -37,6 +58,7 @@ describe('getStatus', () => {
     health.getSmtpStatus = jest.fn().mockResolvedValue({});
 
     const result = await health.getStatus();
+
     expect(result).toBeTruthy();
     expect(result.length).toEqual(1);
   });

--- a/app/tests/unit/components/health.spec.js
+++ b/app/tests/unit/components/health.spec.js
@@ -3,7 +3,7 @@ const health = require('../../../src/components/health');
 
 helper.logHelper();
 
-let mockConnFn = jest.fn();
+const mockConnFn = jest.fn();
 jest.mock('../../../src/services/emailConn', () => {
   return jest.fn(() => {
     return {

--- a/app/tests/unit/components/transformer.spec.js
+++ b/app/tests/unit/components/transformer.spec.js
@@ -4,9 +4,7 @@ const transformer = require('../../../src/components/transformer');
 helper.logHelper();
 
 describe('toStatusResponse', () => {
-  it('should return a null populated object', () => {
-    const result = transformer.toStatusResponse({});
-
+  const nullPopulatedExpectations = result => {
     expect(result).toBeTruthy();
     expect(Object.keys(result)).toHaveLength(8);
     expect(result.createdTS).toBeNull();
@@ -18,6 +16,30 @@ describe('toStatusResponse', () => {
     expect(result.tag).toBeNull();
     expect(result.txId).toBeNull();
     expect(result.updatedTS).toBeNull();
+  };
+
+  it('should return a null populated object with a number', () => {
+    const result = transformer.toStatusResponse(3);
+
+    nullPopulatedExpectations(result);
+  });
+
+  it('should return a null populated object with a string', () => {
+    const result = transformer.toStatusResponse('string');
+
+    nullPopulatedExpectations(result);
+  });
+
+  it('should return a null populated object with an empty array', () => {
+    const result = transformer.toStatusResponse([]);
+
+    nullPopulatedExpectations(result);
+  });
+
+  it('should return a null populated object with an empty object', () => {
+    const result = transformer.toStatusResponse({});
+
+    nullPopulatedExpectations(result);
   });
 
   it('should return an object with createdTS', () => {
@@ -114,6 +136,66 @@ describe('toStatusResponse', () => {
 });
 
 describe('toTransactionResponse', () => {
+  it('should return a null populated object with a number', () => {
+    const result = transformer.toTransactionResponse(3);
+
+    expect(result).toBeTruthy();
+    expect(Object.keys(result)).toHaveLength(2);
+    expect(result.txId).toBeNull();
+    expect(result.messages).toBeTruthy();
+    expect(Array.isArray(result.messages)).toBeTruthy();
+    expect(result.messages).toHaveLength(0);
+  });
+
+  it('should return a null populated object with a string', () => {
+    const result = transformer.toTransactionResponse('string');
+
+    expect(result).toBeTruthy();
+    expect(Object.keys(result)).toHaveLength(2);
+    expect(result.txId).toBeNull();
+    expect(result.messages).toBeTruthy();
+    expect(Array.isArray(result.messages)).toBeTruthy();
+    expect(result.messages).toHaveLength(0);
+  });
+
+  it('should return a null populated object with an empty array', () => {
+    const result = transformer.toTransactionResponse([]);
+
+    expect(result).toBeTruthy();
+    expect(Object.keys(result)).toHaveLength(2);
+    expect(result.txId).toBeNull();
+    expect(result.messages).toBeTruthy();
+    expect(Array.isArray(result.messages)).toBeTruthy();
+    expect(result.messages).toHaveLength(0);
+  });
+
+  it('should return a null populated object with an empty object', () => {
+    const result = transformer.toTransactionResponse({});
+
+    expect(result).toBeTruthy();
+    expect(Object.keys(result)).toHaveLength(2);
+    expect(result.txId).toBeNull();
+    expect(result.messages).toBeTruthy();
+    expect(Array.isArray(result.messages)).toBeTruthy();
+    expect(result.messages).toHaveLength(0);
+  });
+
+  it('should return an object with an empty message', () => {
+    const result = transformer.toTransactionResponse({
+      messages: [{}],
+      transactionId: '00000000-0000-0000-0000-000000000000'
+    });
+
+    expect(result).toBeTruthy();
+    expect(Object.keys(result)).toHaveLength(2);
+    expect(result.txId).toBe('00000000-0000-0000-0000-000000000000');
+    expect(result.messages).toBeTruthy();
+    expect(Array.isArray(result.messages)).toBeTruthy();
+    expect(result.messages).toHaveLength(1);
+    expect(result.messages[0].msgId).toBeNull();
+    expect(result.messages[0].to).toBeNull();
+  });
+
   it('should return an object with all properties populated', () => {
     const result = transformer.toTransactionResponse({
       messages: [
@@ -137,6 +219,7 @@ describe('toTransactionResponse', () => {
     expect(Object.keys(result)).toHaveLength(2);
     expect(result.txId).toBe('00000000-0000-0000-0000-000000000000');
     expect(result.messages).toBeTruthy();
+    expect(Array.isArray(result.messages)).toBeTruthy();
     expect(result.messages).toHaveLength(2);
     expect(result.messages[0].msgId).toBe('00000000-0000-0000-0000-000000000001');
     expect(result.messages[0].to).toBe('foo@example.com');

--- a/app/tests/unit/components/transformer.spec.js
+++ b/app/tests/unit/components/transformer.spec.js
@@ -8,10 +8,15 @@ describe('toStatusResponse', () => {
     const result = transformer.toStatusResponse({});
 
     expect(result).toBeTruthy();
-    expect(Object.keys(result).length).toBe(4);
+    expect(Object.keys(result)).toHaveLength(8);
     expect(result.createdTS).toBeNull();
     expect(result.delayTS).toBeNull();
+    expect(result.msgId).toBeNull();
+    expect(result.status).toBeNull();
+    expect(Array.isArray(result.statusHistory)).toBeTruthy();
+    expect(result.statusHistory).toHaveLength(0);
     expect(result.tag).toBeNull();
+    expect(result.txId).toBeNull();
     expect(result.updatedTS).toBeNull();
   });
 
@@ -21,7 +26,7 @@ describe('toStatusResponse', () => {
     });
 
     expect(result).toBeTruthy();
-    expect(Object.keys(result).length).toBe(4);
+    expect(Object.keys(result)).toHaveLength(8);
     expect(result.createdTS).toBe(1571679721833);
   });
 
@@ -31,7 +36,7 @@ describe('toStatusResponse', () => {
     });
 
     expect(result).toBeTruthy();
-    expect(Object.keys(result).length).toBe(4);
+    expect(Object.keys(result)).toHaveLength(8);
     expect(result.delayTS).toBe(0);
   });
 
@@ -41,7 +46,7 @@ describe('toStatusResponse', () => {
     });
 
     expect(result).toBeTruthy();
-    expect(Object.keys(result).length).toBe(5);
+    expect(Object.keys(result)).toHaveLength(8);
     expect(result.msgId).toBe('00000000-0000-0000-0000-000000000000');
   });
 
@@ -51,7 +56,7 @@ describe('toStatusResponse', () => {
     });
 
     expect(result).toBeTruthy();
-    expect(Object.keys(result).length).toBe(5);
+    expect(Object.keys(result)).toHaveLength(8);
     expect(result.status).toBe('completed');
   });
 
@@ -70,8 +75,8 @@ describe('toStatusResponse', () => {
     });
 
     expect(result).toBeTruthy();
-    expect(Object.keys(result).length).toBe(5);
-    expect(result.statusHistory.length).toBe(2);
+    expect(Object.keys(result)).toHaveLength(8);
+    expect(result.statusHistory).toHaveLength(2);
     expect(result.statusHistory[0].description).toBe('text');
     expect(result.statusHistory[0].status).toBe('stuff');
     expect(result.statusHistory[0].timestamp).toBe(1571679721833);
@@ -83,7 +88,7 @@ describe('toStatusResponse', () => {
     });
 
     expect(result).toBeTruthy();
-    expect(Object.keys(result).length).toBe(4);
+    expect(Object.keys(result)).toHaveLength(8);
     expect(result.tag).toBe('tag');
   });
 
@@ -93,7 +98,7 @@ describe('toStatusResponse', () => {
     });
 
     expect(result).toBeTruthy();
-    expect(Object.keys(result).length).toBe(5);
+    expect(Object.keys(result)).toHaveLength(8);
     expect(result.txId).toBe('00000000-0000-0000-0000-000000000000');
   });
 
@@ -103,7 +108,7 @@ describe('toStatusResponse', () => {
     });
 
     expect(result).toBeTruthy();
-    expect(Object.keys(result).length).toBe(4);
+    expect(Object.keys(result)).toHaveLength(8);
     expect(result.updatedTS).toBe(1571679721833);
   });
 });
@@ -129,10 +134,10 @@ describe('toTransactionResponse', () => {
     });
 
     expect(result).toBeTruthy();
-    expect(Object.keys(result).length).toBe(2);
+    expect(Object.keys(result)).toHaveLength(2);
     expect(result.txId).toBe('00000000-0000-0000-0000-000000000000');
     expect(result.messages).toBeTruthy();
-    expect(result.messages.length).toBe(2);
+    expect(result.messages).toHaveLength(2);
     expect(result.messages[0].msgId).toBe('00000000-0000-0000-0000-000000000001');
     expect(result.messages[0].to).toBe('foo@example.com');
   });

--- a/app/tests/unit/components/transformer.spec.js
+++ b/app/tests/unit/components/transformer.spec.js
@@ -4,21 +4,25 @@ const transformer = require('../../../src/components/transformer');
 helper.logHelper();
 
 describe('toStatusResponse', () => {
-  it('should return an empty object if all properties are undefined', () => {
+  it('should return a null populated object', () => {
     const result = transformer.toStatusResponse({});
 
     expect(result).toBeTruthy();
-    expect(Object.keys(result).length).toBe(0);
+    expect(Object.keys(result).length).toBe(4);
+    expect(result.createdTS).toBeNull();
+    expect(result.delayTS).toBeNull();
+    expect(result.tag).toBeNull();
+    expect(result.updatedTS).toBeNull();
   });
 
-  it('should return an object with createdTimestamp', () => {
+  it('should return an object with createdTS', () => {
     const result = transformer.toStatusResponse({
       createdAt: '2019-10-21T17:42:01.833Z'
     });
 
     expect(result).toBeTruthy();
-    expect(Object.keys(result).length).toBe(1);
-    expect(result.createdTimestamp).toBe(1571679721833);
+    expect(Object.keys(result).length).toBe(4);
+    expect(result.createdTS).toBe(1571679721833);
   });
 
   it('should return an object with delayTS', () => {
@@ -27,7 +31,7 @@ describe('toStatusResponse', () => {
     });
 
     expect(result).toBeTruthy();
-    expect(Object.keys(result).length).toBe(1);
+    expect(Object.keys(result).length).toBe(4);
     expect(result.delayTS).toBe(0);
   });
 
@@ -37,7 +41,7 @@ describe('toStatusResponse', () => {
     });
 
     expect(result).toBeTruthy();
-    expect(Object.keys(result).length).toBe(1);
+    expect(Object.keys(result).length).toBe(5);
     expect(result.msgId).toBe('00000000-0000-0000-0000-000000000000');
   });
 
@@ -47,7 +51,7 @@ describe('toStatusResponse', () => {
     });
 
     expect(result).toBeTruthy();
-    expect(Object.keys(result).length).toBe(1);
+    expect(Object.keys(result).length).toBe(5);
     expect(result.status).toBe('completed');
   });
 
@@ -66,7 +70,7 @@ describe('toStatusResponse', () => {
     });
 
     expect(result).toBeTruthy();
-    expect(Object.keys(result).length).toBe(1);
+    expect(Object.keys(result).length).toBe(5);
     expect(result.statusHistory.length).toBe(2);
     expect(result.statusHistory[0].description).toBe('text');
     expect(result.statusHistory[0].status).toBe('stuff');
@@ -79,7 +83,7 @@ describe('toStatusResponse', () => {
     });
 
     expect(result).toBeTruthy();
-    expect(Object.keys(result).length).toBe(1);
+    expect(Object.keys(result).length).toBe(4);
     expect(result.tag).toBe('tag');
   });
 
@@ -89,18 +93,18 @@ describe('toStatusResponse', () => {
     });
 
     expect(result).toBeTruthy();
-    expect(Object.keys(result).length).toBe(1);
+    expect(Object.keys(result).length).toBe(5);
     expect(result.txId).toBe('00000000-0000-0000-0000-000000000000');
   });
 
-  it('should return an object with updatedTimestamp', () => {
+  it('should return an object with updatedTS', () => {
     const result = transformer.toStatusResponse({
       updatedAt: '2019-10-21T17:42:01.833Z'
     });
 
     expect(result).toBeTruthy();
-    expect(Object.keys(result).length).toBe(1);
-    expect(result.updatedTimestamp).toBe(1571679721833);
+    expect(Object.keys(result).length).toBe(4);
+    expect(result.updatedTS).toBe(1571679721833);
   });
 });
 

--- a/app/tests/unit/components/transformer.spec.js
+++ b/app/tests/unit/components/transformer.spec.js
@@ -1,0 +1,135 @@
+const helper = require('../../common/helper');
+const transformer = require('../../../src/components/transformer');
+
+helper.logHelper();
+
+describe('toStatusResponse', () => {
+  it('should return an empty object if all properties are undefined', () => {
+    const result = transformer.toStatusResponse({});
+
+    expect(result).toBeTruthy();
+    expect(Object.keys(result).length).toBe(0);
+  });
+
+  it('should return an object with createdTimestamp', () => {
+    const result = transformer.toStatusResponse({
+      createdAt: '2019-10-21T17:42:01.833Z'
+    });
+
+    expect(result).toBeTruthy();
+    expect(Object.keys(result).length).toBe(1);
+    expect(result.createdTimestamp).toBe(1571679721833);
+  });
+
+  it('should return an object with delayTS', () => {
+    const result = transformer.toStatusResponse({
+      delayTimestamp: '0'
+    });
+
+    expect(result).toBeTruthy();
+    expect(Object.keys(result).length).toBe(1);
+    expect(result.delayTS).toBe(0);
+  });
+
+  it('should return an object with msgId', () => {
+    const result = transformer.toStatusResponse({
+      messageId: '00000000-0000-0000-0000-000000000000'
+    });
+
+    expect(result).toBeTruthy();
+    expect(Object.keys(result).length).toBe(1);
+    expect(result.msgId).toBe('00000000-0000-0000-0000-000000000000');
+  });
+
+  it('should return an object with status', () => {
+    const result = transformer.toStatusResponse({
+      status: 'completed'
+    });
+
+    expect(result).toBeTruthy();
+    expect(Object.keys(result).length).toBe(1);
+    expect(result.status).toBe('completed');
+  });
+
+  it('should return an object with statusHistory array', () => {
+    const historyObj = {
+      createdAt: '2019-10-21T17:42:01.833Z',
+      description: 'text',
+      status: 'stuff'
+    };
+
+    const result = transformer.toStatusResponse({
+      statusHistory: [
+        historyObj,
+        historyObj
+      ]
+    });
+
+    expect(result).toBeTruthy();
+    expect(Object.keys(result).length).toBe(1);
+    expect(result.statusHistory.length).toBe(2);
+    expect(result.statusHistory[0].description).toBe('text');
+    expect(result.statusHistory[0].status).toBe('stuff');
+    expect(result.statusHistory[0].timestamp).toBe(1571679721833);
+  });
+
+  it('should return an object with tag', () => {
+    const result = transformer.toStatusResponse({
+      tag: 'tag'
+    });
+
+    expect(result).toBeTruthy();
+    expect(Object.keys(result).length).toBe(1);
+    expect(result.tag).toBe('tag');
+  });
+
+  it('should return an object with txId', () => {
+    const result = transformer.toStatusResponse({
+      transactionId: '00000000-0000-0000-0000-000000000000'
+    });
+
+    expect(result).toBeTruthy();
+    expect(Object.keys(result).length).toBe(1);
+    expect(result.txId).toBe('00000000-0000-0000-0000-000000000000');
+  });
+
+  it('should return an object with updatedTimestamp', () => {
+    const result = transformer.toStatusResponse({
+      updatedAt: '2019-10-21T17:42:01.833Z'
+    });
+
+    expect(result).toBeTruthy();
+    expect(Object.keys(result).length).toBe(1);
+    expect(result.updatedTimestamp).toBe(1571679721833);
+  });
+});
+
+describe('toTransactionResponse', () => {
+  it('should return an object with all properties populated', () => {
+    const result = transformer.toTransactionResponse({
+      messages: [
+        {
+          email: {
+            to: 'foo@example.com'
+          },
+          messageId: '00000000-0000-0000-0000-000000000001'
+        },
+        {
+          email: {
+            to: 'bar@example.com'
+          },
+          messageId: '00000000-0000-0000-0000-000000000002'
+        }
+      ],
+      transactionId: '00000000-0000-0000-0000-000000000000'
+    });
+
+    expect(result).toBeTruthy();
+    expect(Object.keys(result).length).toBe(2);
+    expect(result.txId).toBe('00000000-0000-0000-0000-000000000000');
+    expect(result.messages).toBeTruthy();
+    expect(result.messages.length).toBe(2);
+    expect(result.messages[0].msgId).toBe('00000000-0000-0000-0000-000000000001');
+    expect(result.messages[0].to).toBe('foo@example.com');
+  });
+});

--- a/app/tests/unit/components/utils.spec.js
+++ b/app/tests/unit/components/utils.spec.js
@@ -42,7 +42,34 @@ describe('calculateDelayTS', () => {
   });
 });
 
-describe('filterUndefinedAndEmpty', () => {
+describe('dropNullUndefined', () => {
+  const obj = {
+    foo: undefined,
+    bar: 'baz',
+    herp: {
+      lol: 'yes',
+      bad: null,
+      uh: undefined
+    }
+  };
+
+  it('should drop undefined and null properties', () => {
+    const result = utils.dropNullAndUndefinedObject(obj);
+
+    expect(result).toBeTruthy();
+    expect(result.foo).toBeUndefined();
+    expect(result.bar).toMatch('baz');
+    expect(Object.keys(result).length).toEqual(2);
+
+    expect(result.herp).toBeTruthy();
+    expect(result.herp.lol).toMatch('yes');
+    expect(result.herp.bad).toBeUndefined();
+    expect(result.herp.uh).toBeUndefined();
+    expect(Object.keys(result.herp).length).toEqual(1);
+  });
+});
+
+describe('filterUndefinedAndEmptyArray', () => {
   const obj = {
     foo: undefined,
     bar: [],
@@ -53,7 +80,7 @@ describe('filterUndefinedAndEmpty', () => {
   };
 
   it('should drop undefined properties', () => {
-    const result = utils.filterUndefinedAndEmpty(obj);
+    const result = utils.filterUndefinedAndEmptyArray(obj);
 
     expect(result).toBeTruthy();
     expect(result.foo).toBeUndefined();
@@ -62,7 +89,7 @@ describe('filterUndefinedAndEmpty', () => {
   });
 
   it('should drop empty array properties', () => {
-    const result = utils.filterUndefinedAndEmpty(obj);
+    const result = utils.filterUndefinedAndEmptyArray(obj);
 
     expect(result).toBeTruthy();
     expect(result.bar).toBeUndefined();

--- a/app/tests/unit/components/utils.spec.js
+++ b/app/tests/unit/components/utils.spec.js
@@ -42,7 +42,7 @@ describe('calculateDelayTS', () => {
   });
 });
 
-describe('dropNullUndefined', () => {
+describe('dropNullAndUndefinedObject', () => {
   const obj = {
     foo: undefined,
     bar: 'baz',

--- a/app/tests/unit/components/utils.spec.js
+++ b/app/tests/unit/components/utils.spec.js
@@ -42,7 +42,7 @@ describe('calculateDelayTS', () => {
   });
 });
 
-describe('dropNullAndUndefinedObject', () => {
+describe('dropUndefinedObject', () => {
   const obj = {
     foo: undefined,
     bar: 'baz',
@@ -53,8 +53,8 @@ describe('dropNullAndUndefinedObject', () => {
     }
   };
 
-  it('should drop undefined and null properties', () => {
-    const result = utils.dropNullAndUndefinedObject(obj);
+  it('should only drop undefined properties', () => {
+    const result = utils.dropUndefinedObject(obj);
 
     expect(result).toBeTruthy();
     expect(result.foo).toBeUndefined();
@@ -63,9 +63,9 @@ describe('dropNullAndUndefinedObject', () => {
 
     expect(result.herp).toBeTruthy();
     expect(result.herp.lol).toMatch('yes');
-    expect(result.herp.bad).toBeUndefined();
+    expect(result.herp.bad).toBeNull();
     expect(result.herp.uh).toBeUndefined();
-    expect(Object.keys(result.herp).length).toEqual(1);
+    expect(Object.keys(result.herp).length).toEqual(2);
   });
 });
 

--- a/app/tests/unit/components/validators.spec.js
+++ b/app/tests/unit/components/validators.spec.js
@@ -1991,3 +1991,140 @@ describe('queryParams.txId', () => {
     expect(fn([])).toBeFalsy();
   });
 });
+
+describe('statusQuery', () => {
+  let query;
+
+  beforeEach(() => {
+    query = {
+      fields: 'createdTimestamp,delayTS,updatedTimestamp',
+      msgId: '00000000-0000-0000-0000-000000000000',
+      status: 'completed',
+      tag: 'tag',
+      txId: '00000000-0000-0000-0000-000000000000'
+    };
+  });
+
+  it('should return an empty error array when all valid', () => {
+    const result = validators.statusQuery(query);
+
+    expect(result).toBeTruthy();
+    expect(Array.isArray(result)).toBeTruthy();
+    expect(result.length).toEqual(0);
+  });
+
+  it('should return an empty error array with some missing parameters', () => {
+    delete query.status;
+    delete query.txId;
+
+    const result = validators.statusQuery(query);
+
+    expect(result).toBeTruthy();
+    expect(Array.isArray(result)).toBeTruthy();
+    expect(result.length).toEqual(0);
+  });
+
+  it('should return an error when all parameters are missing', () => {
+    const result = validators.statusQuery({});
+
+    expect(result).toBeTruthy();
+    expect(Array.isArray(result)).toBeTruthy();
+    expect(result.length).toEqual(1);
+    expect(result[0].message).toMatch(/At least one of/);
+    expect(result[0].value).toMatch(/params/);
+  });
+
+  it('should return an error with invalid field content', () => {
+    query.fields = 'garbage,delayTS';
+
+    const result = validators.statusQuery(query);
+
+    expect(result).toBeTruthy();
+    expect(Array.isArray(result)).toBeTruthy();
+    expect(result.length).toEqual(1);
+    expect(result[0].message).toMatch(/Value.*is not one of/);
+    expect(result[0].value).toMatch(/fields/);
+  });
+});
+
+describe('statusQueryFields', () => {
+  let query;
+
+  beforeEach(() => {
+    query = {
+      msgId: '00000000-0000-0000-0000-000000000000',
+      status: 'completed',
+      tag: 'tag',
+      txId: '00000000-0000-0000-0000-000000000000'
+    };
+  });
+
+  it('should return an empty error array when all valid', () => {
+    const result = validators.statusQueryFields(query);
+
+    expect(result).toBeTruthy();
+    expect(Array.isArray(result)).toBeTruthy();
+    expect(result.length).toEqual(0);
+  });
+
+  it('should return an error when msgId is invalid', () => {
+    query.msgId = 'garbage';
+
+    const result = validators.statusQueryFields(query);
+
+    expect(result).toBeTruthy();
+    expect(Array.isArray(result)).toBeTruthy();
+    expect(result.length).toEqual(1);
+    expect(result[0].message).toMatch(/msgId/);
+    expect(result[0].value).toBe(query.msgId);
+  });
+
+  it('should return an error when status is invalid', () => {
+    query.status = [];
+
+    const result = validators.statusQueryFields(query);
+
+    expect(result).toBeTruthy();
+    expect(Array.isArray(result)).toBeTruthy();
+    expect(result.length).toEqual(1);
+    expect(result[0].message).toMatch(/status/);
+    expect(result[0].value).toBe(query.status);
+  });
+
+  it('should return an error when tag is invalid', () => {
+    query.tag = [];
+
+    const result = validators.statusQueryFields(query);
+
+    expect(result).toBeTruthy();
+    expect(Array.isArray(result)).toBeTruthy();
+    expect(result.length).toEqual(1);
+    expect(result[0].message).toMatch(/tag/);
+    expect(result[0].value).toBe(query.tag);
+  });
+
+  it('should return an error when txId is invalid', () => {
+    query.txId = 'garbage';
+
+    const result = validators.statusQueryFields(query);
+
+    expect(result).toBeTruthy();
+    expect(Array.isArray(result)).toBeTruthy();
+    expect(result.length).toEqual(1);
+    expect(result[0].message).toMatch(/txId/);
+    expect(result[0].value).toBe(query.txId);
+  });
+
+  it('should return multiple errors with multiple invalid values', () => {
+    const result = validators.statusQueryFields({
+      msgId: 'garbage',
+      status: [],
+      tag: [],
+      txId: 'garbage'
+    });
+
+    expect(result).toBeTruthy();
+    expect(Array.isArray(result)).toBeTruthy();
+    expect(result.length).toEqual(4);
+  });
+});

--- a/app/tests/unit/components/validators.spec.js
+++ b/app/tests/unit/components/validators.spec.js
@@ -1798,7 +1798,7 @@ describe('validators.statusFetch', () => {
 
   beforeEach(() => {
     param = {
-      fields: 'createdTimestamp,delayTS,updatedTimestamp'
+      msgId: '00000000-0000-0000-0000-000000000000',
     };
   });
 

--- a/app/tests/unit/components/validators.spec.js
+++ b/app/tests/unit/components/validators.spec.js
@@ -1,448 +1,249 @@
-const { validators, validatorUtils } = require('../../../src/components/validators');
+const helper = require('../../common/helper');
+
+const { models, validators, validatorUtils } = require('../../../src/components/validators');
 const { realSmallFile, smallFile } = require('../../fixtures/base64Files');
 
-describe('validatorUtils.isEmail', () => {
+helper.logHelper();
 
-  it('should return true for email address', () => {
-    const result = validatorUtils.isEmail('email@address.com');
-
-    expect(result).toBeTruthy();
-  });
-
-  it('should return true for email address with display name', () => {
-    const result = validatorUtils.isEmail('Email Address <email@address.com>');
-
-    expect(result).toBeTruthy();
-  });
-
-  it('should return false for non-email address value', () => {
-    const result = validatorUtils.isEmail('this is not an email');
-
-    expect(result).toBeFalsy();
-  });
-
-  it('should return false for empty value', () => {
-    const result = validatorUtils.isEmail('');
-
-    expect(result).toBeFalsy();
-  });
-
-  it('should return false for whitespace value', () => {
-    const result = validatorUtils.isEmail('            ');
-
-    expect(result).toBeFalsy();
-  });
-
-  it('should return false for undefined value', () => {
-    const result = validatorUtils.isEmail(undefined);
-
-    expect(result).toBeFalsy();
-  });
-
-  it('should return false for non-string value', () => {
-    const result = validatorUtils.isEmail(123);
-
-    expect(result).toBeFalsy();
-  });
-
-});
-
-describe('validatorUtils.isEmailList', () => {
-
-  it('should return true for array of email addresses', () => {
-    const list = ['email@address.com', 'email2@address2.com'];
-    const result = validatorUtils.isEmailList(list);
-
-    expect(result).toBeTruthy();
-  });
-
-  it('should return true for array of email addresses with display names', () => {
-    const list = ['Email Address <email@address.com>', 'Email Address II <email2@address2.com>'];
-    const result = validatorUtils.isEmailList(list);
-
-    expect(result).toBeTruthy();
-  });
-
-  it('should return true for array of email addresses, some with display names', () => {
-    const list = ['email@address.com', '"Email Address Jr." <email2@address2.com>'];
-    const result = validatorUtils.isEmailList(list);
-
-    expect(result).toBeTruthy();
-  });
-
-  it('should return true for an empty array', () => {
-    const list = [];
-    const result = validatorUtils.isEmailList(list);
-
-    expect(result).toBeTruthy();
-  });
-
-  it('should return false for non-array value', () => {
-    const result = validatorUtils.isEmailList({ field: 'value' });
-
-    expect(result).toBeFalsy();
-  });
-
-  it('should return false for string value', () => {
-    const result = validatorUtils.isEmailList('');
-
-    expect(result).toBeFalsy();
-  });
-
-  it('should return false for undefined value', () => {
-    const result = validatorUtils.isEmailList(undefined);
-
-    expect(result).toBeFalsy();
-  });
-
-});
-
-describe('validatorUtils.isInt', () => {
-
-  it('should return true for a int', () => {
-    const value = 123;
-    const result = validatorUtils.isInt(value);
-
-    expect(result).toBeTruthy();
-  });
-
-  it('should return true for a integer as string ', () => {
-    const value = '123456';
-    const result = validatorUtils.isInt(value);
-
-    expect(result).toBeTruthy();
-  });
-
-  it('should return true for a integer as string object ', () => {
-    const value = String(123456);
-    const result = validatorUtils.isInt(value);
-
-    expect(result).toBeTruthy();
-  });
-
-  it('should return false for a non-numeric string ', () => {
-    const value = 'abcdefg1234567';
-    const result = validatorUtils.isInt(value);
-
-    expect(result).toBeFalsy();
-  });
-
-  it('should return false for a float ', () => {
-    const value = 123.45;
-    const result = validatorUtils.isInt(value);
-
-    expect(result).toBeFalsy();
-  });
-
-  it('should return false for a float string ', () => {
-    const value = '123.45';
-    const result = validatorUtils.isInt(value);
-
-    expect(result).toBeFalsy();
-  });
-
-  it('should return false for an array', () => {
-    const result = validatorUtils.isInt([{ value: 123 }]);
-
-    expect(result).toBeFalsy();
-  });
-
-  it('should return false for a function', () => {
-    const value = x => {
-      return String(x);
-    };
-    const result = validatorUtils.isInt(value);
-
-    expect(result).toBeFalsy();
-  });
-
-});
-
-describe('validatorUtils.isString', () => {
-
-  it('should return true for a string', () => {
-    const value = 'this is a string';
-    const result = validatorUtils.isString(value);
-
-    expect(result).toBeTruthy();
-  });
-
-  it('should return true for a string object ', () => {
-    const value = String(123456);
-    const result = validatorUtils.isString(value);
-
-    expect(result).toBeTruthy();
-  });
-
-  it('should return false for a number ', () => {
-    const value = 123456;
-    const result = validatorUtils.isString(value);
-
-    expect(result).toBeFalsy();
-  });
-
-  it('should return false for a non-string object ', () => {
-    const result = validatorUtils.isString({ value: 'string' });
-
-    expect(result).toBeFalsy();
-  });
-
-  it('should return false for an array', () => {
-    const result = validatorUtils.isString([{ value: 'string' }]);
-
-    expect(result).toBeFalsy();
-  });
-
-  it('should return false for a function', () => {
-    const value = x => {
-      return String(x);
-    };
-    const result = validatorUtils.isString(value);
-
-    expect(result).toBeFalsy();
-  });
-
-});
-
-describe('attachment.content', () => {
+describe('models.attachment.content', () => {
 
   it('should return true for populated string', () => {
     const value = 'this is a populated string';
-    const result = validators.attachment.content(value);
+    const result = models.attachment.content(value);
     expect(result).toBeTruthy();
   });
 
   it('should return true for populated string object', () => {
     const value = String('this is a populated string');
-    const result = validators.attachment.content(value);
+    const result = models.attachment.content(value);
     expect(result).toBeTruthy();
   });
 
   it('should return false for undefined', () => {
     const value = undefined;
-    const result = validators.attachment.content(value);
+    const result = models.attachment.content(value);
     expect(result).toBeFalsy();
   });
 
   it('should return false for empty string', () => {
     const value = '';
-    const result = validators.attachment.content(value);
+    const result = models.attachment.content(value);
     expect(result).toBeFalsy();
   });
 
   it('should return false for whitespace string', () => {
     const value = '                     ';
-    const result = validators.attachment.content(value);
+    const result = models.attachment.content(value);
     expect(result).toBeFalsy();
   });
 
   it('should return false for array argument', () => {
     const value = [];
-    const result = validators.attachment.content(value);
+    const result = models.attachment.content(value);
     expect(result).toBeFalsy();
   });
 
   it('should return false for number argument', () => {
     const value = 123;
-    const result = validators.attachment.content(value);
+    const result = models.attachment.content(value);
     expect(result).toBeFalsy();
   });
 
   it('should return false for object argument', () => {
     const value = { value: 123 };
-    const result = validators.attachment.content(value);
+    const result = models.attachment.content(value);
     expect(result).toBeFalsy();
   });
 
 });
 
-describe('attachment.contentType', () => {
+describe('models.attachment.contentType', () => {
 
   it('should return true for populated string', () => {
     const value = 'this is the content type';
-    const result = validators.attachment.contentType(value);
+    const result = models.attachment.contentType(value);
     expect(result).toBeTruthy();
   });
 
   it('should return true for populated string object', () => {
     const value = String('this is the content type');
-    const result = validators.attachment.contentType(value);
+    const result = models.attachment.contentType(value);
     expect(result).toBeTruthy();
   });
 
   it('should return true for undefined', () => {
     const value = undefined;
-    const result = validators.attachment.contentType(value);
+    const result = models.attachment.contentType(value);
     expect(result).toBeTruthy();
   });
 
   it('should return true for empty string', () => {
     const value = '';
-    const result = validators.attachment.contentType(value);
+    const result = models.attachment.contentType(value);
     expect(result).toBeTruthy();
   });
 
   it('should return false for all whitespace string', () => {
     const value = '           ';
-    const result = validators.attachment.contentType(value);
+    const result = models.attachment.contentType(value);
     expect(result).toBeFalsy();
   });
 
   it('should return false for non-string value', () => {
     const value = 123;
-    const result = validators.attachment.contentType(value);
+    const result = models.attachment.contentType(value);
     expect(result).toBeFalsy();
   });
 
 });
 
-describe('attachment.encoding', () => {
+describe('models.attachment.encoding', () => {
 
   it('should return true for "base64"', () => {
     const value = 'base64';
-    const result = validators.attachment.encoding(value);
+    const result = models.attachment.encoding(value);
     expect(result).toBeTruthy();
   });
 
   it('should return true for "binary"', () => {
     const value = 'binary';
-    const result = validators.attachment.encoding(value);
+    const result = models.attachment.encoding(value);
     expect(result).toBeTruthy();
   });
 
   it('should return true for "hex"', () => {
     const value = 'hex';
-    const result = validators.attachment.encoding(value);
+    const result = models.attachment.encoding(value);
     expect(result).toBeTruthy();
   });
 
   it('should return true for undefined', () => {
     const value = undefined;
-    const result = validators.attachment.encoding(value);
+    const result = models.attachment.encoding(value);
     expect(result).toBeTruthy();
   });
 
   it('should return true for empty string', () => {
     const value = '';
-    const result = validators.attachment.encoding(value);
+    const result = models.attachment.encoding(value);
     expect(result).toBeTruthy();
   });
 
   it('should return false for all whitespace string', () => {
     const value = '           ';
-    const result = validators.attachment.encoding(value);
+    const result = models.attachment.encoding(value);
     expect(result).toBeFalsy();
   });
 
   it('should return false for invalid value', () => {
     const value = 'xhexx';
-    const result = validators.attachment.encoding(value);
+    const result = models.attachment.encoding(value);
     expect(result).toBeFalsy();
   });
 
   it('should return false for non-string value', () => {
     const value = 123;
-    const result = validators.attachment.encoding(value);
+    const result = models.attachment.encoding(value);
     expect(result).toBeFalsy();
   });
 
 });
 
-describe('attachment.filename', () => {
+describe('models.attachment.filename', () => {
 
   it('should return true for populated string', () => {
     const value = 'this is a populated string';
-    const result = validators.attachment.filename(value);
+    const result = models.attachment.filename(value);
     expect(result).toBeTruthy();
   });
 
   it('should return true for populated string object', () => {
     const value = String('this is a populated string');
-    const result = validators.attachment.filename(value);
+    const result = models.attachment.filename(value);
     expect(result).toBeTruthy();
   });
 
   it('should return false for undefined', () => {
     const value = undefined;
-    const result = validators.attachment.filename(value);
+    const result = models.attachment.filename(value);
     expect(result).toBeFalsy();
   });
 
   it('should return false for empty string', () => {
     const value = '';
-    const result = validators.attachment.filename(value);
+    const result = models.attachment.filename(value);
     expect(result).toBeFalsy();
   });
 
   it('should return false for whitespace string', () => {
     const value = '                     ';
-    const result = validators.attachment.filename(value);
+    const result = models.attachment.filename(value);
     expect(result).toBeFalsy();
   });
 
   it('should return false for array argument', () => {
     const value = [];
-    const result = validators.attachment.filename(value);
+    const result = models.attachment.filename(value);
     expect(result).toBeFalsy();
   });
 
   it('should return false for number argument', () => {
     const value = 123;
-    const result = validators.attachment.filename(value);
+    const result = models.attachment.filename(value);
     expect(result).toBeFalsy();
   });
 
   it('should return false for object argument', () => {
     const value = { value: 123 };
-    const result = validators.attachment.filename(value);
+    const result = models.attachment.filename(value);
     expect(result).toBeFalsy();
   });
 
   it('should return true for file size equal to limit', async () => {
     const content = smallFile.content;
-    const result = await validators.attachment.size(content, 'base64', smallFile.size);
+    const result = await models.attachment.size(content, 'base64', smallFile.size);
     expect(result).toBeTruthy();
   });
 
   it('should return true for file smaller than limit', async () => {
     const content = smallFile.content;
-    const result = await validators.attachment.size(content, 'base64', smallFile.size + 1);
+    const result = await models.attachment.size(content, 'base64', smallFile.size + 1);
     expect(result).toBeTruthy();
   });
 
   it('should return false for file larger than limit', async () => {
     const content = smallFile.content;
-    const result = await validators.attachment.size(content, 'base64', smallFile.size - 1);
+    const result = await models.attachment.size(content, 'base64', smallFile.size - 1);
     expect(result).toBeFalsy();
   });
 
   it('should return false for no content', async () => {
     const content = '';
-    const result = await validators.attachment.size(content, 'base64', smallFile.size);
+    const result = await models.attachment.size(content, 'base64', smallFile.size);
     expect(result).toBeFalsy();
   });
 
   it('should return false for invalid encoding', async () => {
     const content = smallFile.content;
-    const result = await validators.attachment.size(content, 'base64xxx', smallFile.size);
+    const result = await models.attachment.size(content, 'base64xxx', smallFile.size);
     expect(result).toBeFalsy();
   });
 
   it('should return true for bytes parseable limit', async () => {
     const content = smallFile.content;
-    const result = await validators.attachment.size(content, 'base64', '1mb');
+    const result = await models.attachment.size(content, 'base64', '1mb');
     expect(result).toBeTruthy();
   });
 
   it('should return false for invalid limit', async () => {
     const content = smallFile.content;
-    const result = await validators.attachment.size(content, 'base64', 'bad limit cannot parse');
+    const result = await models.attachment.size(content, 'base64', 'bad limit cannot parse');
     expect(result).toBeFalsy();
   });
 
   it('should return false for limit less than 1 byte', async () => {
     const content = smallFile.content;
-    const result = await validators.attachment.size(content, 'base64', 0);
+    const result = await models.attachment.size(content, 'base64', 0);
     expect(result).toBeFalsy();
   });
 
@@ -454,161 +255,161 @@ describe('attachment.filename', () => {
     });
 
     const content = smallFile.content;
-    const result = await validators.attachment.size(content, 'base64');
+    const result = await models.attachment.size(content, 'base64');
     expect(result).toBeFalsy();
 
     spy.mockRestore();
   });
 });
 
-describe('context.bcc', () => {
+describe('models.context.bcc', () => {
 
   it('should return true for undefined', () => {
     const list = undefined;
-    const result = validators.context.bcc(list);
+    const result = models.context.bcc(list);
     expect(result).toBeTruthy();
   });
 
   it('should return true for empty array', () => {
     const list = [];
-    const result = validators.context.bcc(list);
+    const result = models.context.bcc(list);
     expect(result).toBeTruthy();
   });
 
   it('should return true for array of email addresses', () => {
     const list = ['email@address.com', '"Email Address Jr." <email2@address2.com>'];
-    const result = validators.context.bcc(list);
+    const result = models.context.bcc(list);
     expect(result).toBeTruthy();
   });
 
   it('should return false for array where a value is not an email address', () => {
     const list = ['this is not a valid email value', 'email@address.com', '"Email Address Jr." <email2@address2.com>'];
-    const result = validators.context.bcc(list);
+    const result = models.context.bcc(list);
     expect(result).toBeFalsy();
   });
 
   it('should return false for non-array argument', () => {
     const value = '"Email Address Jr." <email2@address2.com>';
-    const result = validators.context.bcc(value);
+    const result = models.context.bcc(value);
     expect(result).toBeFalsy();
   });
 
 });
 
-describe('context.cc', () => {
+describe('models.context.cc', () => {
 
   it('should return true for undefined', () => {
     const list = undefined;
-    const result = validators.context.cc(list);
+    const result = models.context.cc(list);
     expect(result).toBeTruthy();
   });
 
   it('should return true for empty array', () => {
     const list = [];
-    const result = validators.context.cc(list);
+    const result = models.context.cc(list);
     expect(result).toBeTruthy();
   });
 
   it('should return true for array of email addresses', () => {
     const list = ['email@address.com', '"Email Address Jr." <email2@address2.com>'];
-    const result = validators.context.cc(list);
+    const result = models.context.cc(list);
     expect(result).toBeTruthy();
   });
 
   it('should return false for array where a value is not an email address', () => {
     const list = ['this is not a valid email value', 'email@address.com', '"Email Address Jr." <email2@address2.com>'];
-    const result = validators.context.cc(list);
+    const result = models.context.cc(list);
     expect(result).toBeFalsy();
   });
 
   it('should return false for non-array argument', () => {
     const value = '"Email Address Jr." <email2@address2.com>';
-    const result = validators.context.cc(value);
+    const result = models.context.cc(value);
     expect(result).toBeFalsy();
   });
 
 });
 
-describe('context.delayTS', () => {
+describe('models.context.delayTS', () => {
 
   it('should return true for undefined', () => {
     const value = undefined;
-    const result = validators.context.delayTS(value);
+    const result = models.context.delayTS(value);
     expect(result).toBeTruthy();
   });
 
   it('should return true for int', () => {
     const value = 123;
-    const result = validators.context.delayTS(value);
+    const result = models.context.delayTS(value);
     expect(result).toBeTruthy();
   });
 
   it('should return true for empty string', () => {
     const value = '';
-    const result = validators.context.delayTS(value);
+    const result = models.context.delayTS(value);
     expect(result).toBeTruthy();
   });
 
   it('should return true for int string', () => {
     const value = '123';
-    const result = validators.context.delayTS(value);
+    const result = models.context.delayTS(value);
     expect(result).toBeTruthy();
   });
 
   it('should return true for populated int string object', () => {
     const value = String('123');
-    const result = validators.context.delayTS(value);
+    const result = models.context.delayTS(value);
     expect(result).toBeTruthy();
   });
 
   it('should return false for float', () => {
     const value = 123.45;
-    const result = validators.context.delayTS(value);
+    const result = models.context.delayTS(value);
     expect(result).toBeFalsy();
   });
 
   it('should return false for whitespace string', () => {
     const value = '                     ';
-    const result = validators.context.delayTS(value);
+    const result = models.context.delayTS(value);
     expect(result).toBeFalsy();
   });
 
   it('should return false for array argument', () => {
     const value = [];
-    const result = validators.context.delayTS(value);
+    const result = models.context.delayTS(value);
     expect(result).toBeFalsy();
   });
 
   it('should return false for object argument', () => {
     const value = { value: 123 };
-    const result = validators.context.delayTS(value);
+    const result = models.context.delayTS(value);
     expect(result).toBeFalsy();
   });
 });
 
-describe('context.keys', () => {
+describe('models.context.keys', () => {
 
   it('should return false for undefined', () => {
     const value = undefined;
-    const result = validators.context.keys(value);
+    const result = models.context.keys(value);
     expect(result).toBeFalsy();
   });
 
   it('should return false for string', () => {
     const value = 'this is a string';
-    const result = validators.context.keys(value);
+    const result = models.context.keys(value);
     expect(result).toBeFalsy();
   });
 
   it('should return false for number', () => {
     const value = 123;
-    const result = validators.context.keys(value);
+    const result = models.context.keys(value);
     expect(result).toBeFalsy();
   });
 
   it('should return false for array', () => {
     const value = ['this is a string'];
-    const result = validators.context.keys(value);
+    const result = models.context.keys(value);
     expect(result).toBeFalsy();
   });
 
@@ -618,7 +419,7 @@ describe('context.keys', () => {
       'this_is_a_valid_key_from_json_123': 'pass',
       'subObject': { 'good': 'good key name' }
     };
-    const result = validators.context.keys(value);
+    const result = models.context.keys(value);
     expect(result).toBeTruthy();
   });
 
@@ -629,7 +430,7 @@ describe('context.keys', () => {
       'subObject': { 'good': 'good key name' },
       'a1_&': 'bad key'
     };
-    const result = validators.context.keys(value);
+    const result = models.context.keys(value);
     expect(result).toBeFalsy();
   });
 
@@ -639,598 +440,726 @@ describe('context.keys', () => {
       'this_is_a_valid_key_from_json_123': 'pass',
       'subObject': { 'good': 'good key name', 'a1_&': 'bad key' }
     };
-    const result = validators.context.keys(value);
+    const result = models.context.keys(value);
     expect(result).toBeFalsy();
   });
 
 });
 
-describe('context.tag', () => {
+describe('models.context.tag', () => {
 
   it('should return true for string', () => {
     const value = 'this is a tag';
-    const result = validators.context.tag(value);
+    const result = models.context.tag(value);
     expect(result).toBeTruthy();
   });
 
   it('should return true for string object', () => {
     const value = String('this is a tag');
-    const result = validators.context.tag(value);
+    const result = models.context.tag(value);
     expect(result).toBeTruthy();
   });
 
   it('should return true for undefined', () => {
     const value = undefined;
-    const result = validators.context.tag(value);
+    const result = models.context.tag(value);
     expect(result).toBeTruthy();
   });
 
   it('should return false for number', () => {
     const value = 123;
-    const result = validators.context.tag(value);
+    const result = models.context.tag(value);
     expect(result).toBeFalsy();
   });
 
   it('should return false for object', () => {
     const value = {};
-    const result = validators.context.tag(value);
+    const result = models.context.tag(value);
     expect(result).toBeFalsy();
   });
 
   it('should return false for array', () => {
     const value = [];
-    const result = validators.context.tag(value);
+    const result = models.context.tag(value);
     expect(result).toBeFalsy();
   });
 
 });
 
-describe('contexts.to', () => {
+describe('models.contexts.to', () => {
 
   it('should return false for undefined', () => {
     const list = undefined;
-    const result = validators.context.to(list);
+    const result = models.context.to(list);
     expect(result).toBeFalsy();
   });
 
   it('should return false for empty array', () => {
     const list = [];
-    const result = validators.context.to(list);
+    const result = models.context.to(list);
     expect(result).toBeFalsy();
   });
 
   it('should return true for array of email addresses', () => {
     const list = ['email@address.com', '"Email Address Jr." <email2@address2.com>'];
-    const result = validators.context.to(list);
+    const result = models.context.to(list);
     expect(result).toBeTruthy();
   });
 
   it('should return false for array where a value is not an email address', () => {
     const list = ['this is not a valid email value', 'email@address.com', '"Email Address Jr." <email2@address2.com>'];
-    const result = validators.context.to(list);
+    const result = models.context.to(list);
     expect(result).toBeFalsy();
   });
 
   it('should return false for non-array argument', () => {
     const value = '"Email Address Jr." <email2@address2.com>';
-    const result = validators.context.to(value);
+    const result = models.context.to(value);
     expect(result).toBeFalsy();
   });
 
 });
 
-describe('message.bcc', () => {
+describe('models.message.bcc', () => {
 
   it('should return true for undefined', () => {
     const list = undefined;
-    const result = validators.message.bcc(list);
+    const result = models.message.bcc(list);
     expect(result).toBeTruthy();
   });
 
   it('should return true for empty array', () => {
     const list = [];
-    const result = validators.message.bcc(list);
+    const result = models.message.bcc(list);
     expect(result).toBeTruthy();
   });
 
   it('should return true for array of email addresses', () => {
     const list = ['email@address.com', '"Email Address Jr." <email2@address2.com>'];
-    const result = validators.message.bcc(list);
+    const result = models.message.bcc(list);
     expect(result).toBeTruthy();
   });
 
   it('should return false for array where a value is not an email address', () => {
     const list = ['this is not a valid email value', 'email@address.com', '"Email Address Jr." <email2@address2.com>'];
-    const result = validators.message.bcc(list);
+    const result = models.message.bcc(list);
     expect(result).toBeFalsy();
   });
 
   it('should return false for non-array argument', () => {
     const value = '"Email Address Jr." <email2@address2.com>';
-    const result = validators.message.bcc(value);
+    const result = models.message.bcc(value);
     expect(result).toBeFalsy();
   });
 
 });
 
-describe('message.body', () => {
+describe('models.message.body', () => {
 
   it('should return true for populated string', () => {
     const value = 'this is a populated string';
-    const result = validators.message.body(value);
+    const result = models.message.body(value);
     expect(result).toBeTruthy();
   });
 
   it('should return true for populated string object', () => {
     const value = String('this is a populated string');
-    const result = validators.message.body(value);
+    const result = models.message.body(value);
     expect(result).toBeTruthy();
   });
 
   it('should return false for undefined', () => {
     const value = undefined;
-    const result = validators.message.body(value);
+    const result = models.message.body(value);
     expect(result).toBeFalsy();
   });
 
   it('should return false for empty string', () => {
     const value = '';
-    const result = validators.message.body(value);
+    const result = models.message.body(value);
     expect(result).toBeFalsy();
   });
 
   it('should return false for whitespace string', () => {
     const value = '                     ';
-    const result = validators.message.body(value);
+    const result = models.message.body(value);
     expect(result).toBeFalsy();
   });
 
   it('should return false for array argument', () => {
     const value = [];
-    const result = validators.message.body(value);
+    const result = models.message.body(value);
     expect(result).toBeFalsy();
   });
 
   it('should return false for number argument', () => {
     const value = 123;
-    const result = validators.message.body(value);
+    const result = models.message.body(value);
     expect(result).toBeFalsy();
   });
 
   it('should return false for object argument', () => {
     const value = { value: 123 };
-    const result = validators.message.body(value);
+    const result = models.message.body(value);
     expect(result).toBeFalsy();
   });
 
 });
 
-describe('message.bodyType', () => {
+describe('models.message.bodyType', () => {
 
   it('should return true for "html"', () => {
     const value = 'html';
-    const result = validators.message.bodyType(value);
+    const result = models.message.bodyType(value);
     expect(result).toBeTruthy();
   });
 
   it('should return true for "text"', () => {
     const value = 'text';
-    const result = validators.message.bodyType(value);
+    const result = models.message.bodyType(value);
     expect(result).toBeTruthy();
   });
 
   it('should return false for undefined value', () => {
     const value = undefined;
-    const result = validators.message.bodyType(value);
+    const result = models.message.bodyType(value);
     expect(result).toBeFalsy();
   });
 
   it('should return false for empty value', () => {
     const value = '';
-    const result = validators.message.bodyType(value);
+    const result = models.message.bodyType(value);
     expect(result).toBeFalsy();
   });
 
   it('should return false for invalid value', () => {
     const value = 'xhtmlx';
-    const result = validators.message.bodyType(value);
+    const result = models.message.bodyType(value);
     expect(result).toBeFalsy();
   });
 
 });
 
-describe('message.cc', () => {
+describe('models.message.cc', () => {
 
   it('should return true for undefined', () => {
     const list = undefined;
-    const result = validators.message.cc(list);
+    const result = models.message.cc(list);
     expect(result).toBeTruthy();
   });
 
   it('should return true for empty array', () => {
     const list = [];
-    const result = validators.message.cc(list);
+    const result = models.message.cc(list);
     expect(result).toBeTruthy();
   });
 
   it('should return true for array of email addresses', () => {
     const list = ['email@address.com', '"Email Address Jr." <email2@address2.com>'];
-    const result = validators.message.cc(list);
+    const result = models.message.cc(list);
     expect(result).toBeTruthy();
   });
 
   it('should return false for array where a value is not an email address', () => {
     const list = ['this is not a valid email value', 'email@address.com', '"Email Address Jr." <email2@address2.com>'];
-    const result = validators.message.cc(list);
+    const result = models.message.cc(list);
     expect(result).toBeFalsy();
   });
 
   it('should return false for non-array argument', () => {
     const value = '"Email Address Jr." <email2@address2.com>';
-    const result = validators.message.cc(value);
+    const result = models.message.cc(value);
     expect(result).toBeFalsy();
   });
 
 });
 
-describe('message.delayTS', () => {
+describe('models.message.delayTS', () => {
 
   it('should return true for undefined', () => {
     const value = undefined;
-    const result = validators.message.delayTS(value);
+    const result = models.message.delayTS(value);
     expect(result).toBeTruthy();
   });
 
   it('should return true for int', () => {
     const value = 123;
-    const result = validators.message.delayTS(value);
+    const result = models.message.delayTS(value);
     expect(result).toBeTruthy();
   });
 
   it('should return true for large integers', () => {
     const value = 1569878107287;
-    const result = validators.message.delayTS(value);
+    const result = models.message.delayTS(value);
     expect(result).toBeTruthy();
   });
 
   it('should return true for unix epoch ts', () => {
     const value = 1569879623;
-    const result = validators.message.delayTS(value);
+    const result = models.message.delayTS(value);
     expect(result).toBeTruthy();
   });
 
   it('should return true for empty string', () => {
     const value = '';
-    const result = validators.message.delayTS(value);
+    const result = models.message.delayTS(value);
     expect(result).toBeTruthy();
   });
 
   it('should return true for int string', () => {
     const value = '123';
-    const result = validators.message.delayTS(value);
+    const result = models.message.delayTS(value);
     expect(result).toBeTruthy();
   });
 
   it('should return true for populated int string object', () => {
     const value = String('123');
-    const result = validators.message.delayTS(value);
+    const result = models.message.delayTS(value);
     expect(result).toBeTruthy();
   });
 
   it('should return false for float', () => {
     const value = 123.45;
-    const result = validators.message.delayTS(value);
+    const result = models.message.delayTS(value);
     expect(result).toBeFalsy();
   });
 
   it('should return false for whitespace string', () => {
     const value = '                     ';
-    const result = validators.message.delayTS(value);
+    const result = models.message.delayTS(value);
     expect(result).toBeFalsy();
   });
 
   it('should return false for array argument', () => {
     const value = [];
-    const result = validators.message.delayTS(value);
+    const result = models.message.delayTS(value);
     expect(result).toBeFalsy();
   });
 
   it('should return false for object argument', () => {
     const value = { value: 123 };
-    const result = validators.message.delayTS(value);
+    const result = models.message.delayTS(value);
     expect(result).toBeFalsy();
   });
 });
 
-describe('message.encoding', () => {
+describe('models.message.encoding', () => {
 
   it('should return true for "base64"', () => {
     const value = 'base64';
-    const result = validators.message.encoding(value);
+    const result = models.message.encoding(value);
     expect(result).toBeTruthy();
   });
 
   it('should return true for "binary"', () => {
     const value = 'binary';
-    const result = validators.message.encoding(value);
+    const result = models.message.encoding(value);
     expect(result).toBeTruthy();
   });
 
   it('should return true for "hex"', () => {
     const value = 'hex';
-    const result = validators.message.encoding(value);
+    const result = models.message.encoding(value);
     expect(result).toBeTruthy();
   });
 
   it('should return true for "utf-8"', () => {
     const value = 'utf-8';
-    const result = validators.message.encoding(value);
+    const result = models.message.encoding(value);
     expect(result).toBeTruthy();
   });
 
   it('should return true for undefined', () => {
     const value = undefined;
-    const result = validators.message.encoding(value);
+    const result = models.message.encoding(value);
     expect(result).toBeTruthy();
   });
 
   it('should return true for empty string', () => {
     const value = '';
-    const result = validators.message.encoding(value);
+    const result = models.message.encoding(value);
     expect(result).toBeTruthy();
   });
 
   it('should return false for all whitespace string', () => {
     const value = '           ';
-    const result = validators.message.encoding(value);
+    const result = models.message.encoding(value);
     expect(result).toBeFalsy();
   });
 
   it('should return false for invalid value', () => {
     const value = 'xhexx';
-    const result = validators.message.encoding(value);
+    const result = models.message.encoding(value);
     expect(result).toBeFalsy();
   });
 
   it('should return false for non-string value', () => {
     const value = 123;
-    const result = validators.message.encoding(value);
+    const result = models.message.encoding(value);
     expect(result).toBeFalsy();
   });
 
 });
 
-describe('message.from', () => {
+describe('models.message.from', () => {
 
   it('should return true for email address', () => {
     const value = 'email@address.com';
-    const result = validators.message.from(value);
+    const result = models.message.from(value);
     expect(result).toBeTruthy();
   });
 
   it('should return true for email address with display name', () => {
     const value = 'Email Address <email@address.com>';
-    const result = validators.message.from(value);
+    const result = models.message.from(value);
     expect(result).toBeTruthy();
   });
 
   it('should return false for non-email address', () => {
     const value = 'this is not an email address';
-    const result = validators.message.from(value);
+    const result = models.message.from(value);
     expect(result).toBeFalsy();
   });
 
   it('should return false for undefined', () => {
     const value = undefined;
-    const result = validators.message.from(value);
+    const result = models.message.from(value);
     expect(result).toBeFalsy();
   });
 
   it('should return false for empty string', () => {
     const value = '';
-    const result = validators.message.from(value);
+    const result = models.message.from(value);
     expect(result).toBeFalsy();
   });
 
   it('should return false for whitespace string', () => {
     const value = '     ';
-    const result = validators.message.from(value);
+    const result = models.message.from(value);
     expect(result).toBeFalsy();
   });
 
   it('should return false for array', () => {
     const value = ['email@address.com'];
-    const result = validators.message.from(value);
+    const result = models.message.from(value);
     expect(result).toBeFalsy();
   });
 
   it('should return false for object', () => {
     const value = { from: 'email@address.com' };
-    const result = validators.message.from(value);
+    const result = models.message.from(value);
     expect(result).toBeFalsy();
   });
 
 });
 
-describe('message.priority', () => {
+describe('models.message.priority', () => {
 
   it('should return true for "normal"', () => {
     const value = 'normal';
-    const result = validators.message.priority(value);
+    const result = models.message.priority(value);
     expect(result).toBeTruthy();
   });
 
   it('should return true for "low"', () => {
     const value = 'low';
-    const result = validators.message.priority(value);
+    const result = models.message.priority(value);
     expect(result).toBeTruthy();
   });
 
   it('should return true for "high"', () => {
     const value = 'high';
-    const result = validators.message.priority(value);
+    const result = models.message.priority(value);
     expect(result).toBeTruthy();
   });
 
   it('should return true for undefined', () => {
     const value = undefined;
-    const result = validators.message.priority(value);
+    const result = models.message.priority(value);
     expect(result).toBeTruthy();
   });
 
   it('should return true for empty string', () => {
     const value = '';
-    const result = validators.message.priority(value);
+    const result = models.message.priority(value);
     expect(result).toBeTruthy();
   });
 
   it('should return false for all whitespace string', () => {
     const value = '           ';
-    const result = validators.message.priority(value);
+    const result = models.message.priority(value);
     expect(result).toBeFalsy();
   });
 
   it('should return false for invalid value', () => {
     const value = 'xhighx';
-    const result = validators.message.priority(value);
+    const result = models.message.priority(value);
     expect(result).toBeFalsy();
   });
 
   it('should return false for non-string value', () => {
     const value = 123;
-    const result = validators.message.priority(value);
+    const result = models.message.priority(value);
     expect(result).toBeFalsy();
   });
 
 });
 
-describe('message.subject', () => {
+describe('models.message.subject', () => {
 
   it('should return true for populated string', () => {
     const value = 'this is a populated string';
-    const result = validators.message.subject(value);
+    const result = models.message.subject(value);
     expect(result).toBeTruthy();
   });
 
   it('should return true for populated string object', () => {
     const value = String('this is a populated string');
-    const result = validators.message.subject(value);
+    const result = models.message.subject(value);
     expect(result).toBeTruthy();
   });
 
   it('should return false for undefined', () => {
     const value = undefined;
-    const result = validators.message.subject(value);
+    const result = models.message.subject(value);
     expect(result).toBeFalsy();
   });
 
   it('should return false for empty string', () => {
     const value = '';
-    const result = validators.message.subject(value);
+    const result = models.message.subject(value);
     expect(result).toBeFalsy();
   });
 
   it('should return false for whitespace string', () => {
     const value = '                     ';
-    const result = validators.message.subject(value);
+    const result = models.message.subject(value);
     expect(result).toBeFalsy();
   });
 
   it('should return false for array argument', () => {
     const value = [];
-    const result = validators.message.subject(value);
+    const result = models.message.subject(value);
     expect(result).toBeFalsy();
   });
 
   it('should return false for number argument', () => {
     const value = 123;
-    const result = validators.message.subject(value);
+    const result = models.message.subject(value);
     expect(result).toBeFalsy();
   });
 
   it('should return false for object argument', () => {
     const value = { value: 123 };
-    const result = validators.message.subject(value);
+    const result = models.message.subject(value);
     expect(result).toBeFalsy();
   });
 
 });
 
-describe('message.tag', () => {
+describe('models.message.tag', () => {
 
   it('should return true for string', () => {
     const value = 'this is a tag';
-    const result = validators.message.tag(value);
+    const result = models.message.tag(value);
     expect(result).toBeTruthy();
   });
 
   it('should return true for string object', () => {
     const value = String('this is a tag');
-    const result = validators.message.tag(value);
+    const result = models.message.tag(value);
     expect(result).toBeTruthy();
   });
 
   it('should return true for undefined', () => {
     const value = undefined;
-    const result = validators.message.tag(value);
+    const result = models.message.tag(value);
     expect(result).toBeTruthy();
   });
 
   it('should return false for number', () => {
     const value = 123;
-    const result = validators.message.tag(value);
+    const result = models.message.tag(value);
     expect(result).toBeFalsy();
   });
 
   it('should return false for object', () => {
     const value = {};
-    const result = validators.message.tag(value);
+    const result = models.message.tag(value);
     expect(result).toBeFalsy();
   });
 
   it('should return false for array', () => {
     const value = [];
-    const result = validators.message.tag(value);
+    const result = models.message.tag(value);
     expect(result).toBeFalsy();
   });
 
 });
 
-describe('message.to', () => {
+describe('models.message.to', () => {
 
   it('should return false for undefined', () => {
     const list = undefined;
-    const result = validators.message.to(list);
+    const result = models.message.to(list);
     expect(result).toBeFalsy();
   });
 
   it('should return false for empty array', () => {
     const list = [];
-    const result = validators.message.to(list);
+    const result = models.message.to(list);
     expect(result).toBeFalsy();
   });
 
   it('should return true for array of email addresses', () => {
     const list = ['email@address.com', '"Email Address Jr." <email2@address2.com>'];
-    const result = validators.message.to(list);
+    const result = models.message.to(list);
     expect(result).toBeTruthy();
   });
 
   it('should return false for array where a value is not an email address', () => {
     const list = ['this is not a valid email value', 'email@address.com', '"Email Address Jr." <email2@address2.com>'];
-    const result = validators.message.to(list);
+    const result = models.message.to(list);
     expect(result).toBeFalsy();
   });
 
   it('should return false for non-array argument', () => {
     const value = '"Email Address Jr." <email2@address2.com>';
-    const result = validators.message.to(value);
+    const result = models.message.to(value);
     expect(result).toBeFalsy();
   });
 
 });
 
-describe('attachments list', () => {
+describe('models.queryParams.msgId', () => {
+  const fn = models.queryParams.msgId;
+
+  it('should return true for valid UUID strings', () => {
+    expect(fn('00000000-0000-0000-0000-000000000000')).toBeTruthy();
+    expect(fn('11111111-1111-1111-0111-111111111111')).toBeTruthy();
+    expect(fn('ac2b944a-c148-4dfe-8103-d4cdc6b0a79a')).toBeTruthy();
+    expect(fn('86a12b0d-6d7a-491c-a1fb-98db9543bf55')).toBeTruthy();
+  });
+
+  it('should return true for valid UUID string object', () => {
+    expect(fn(String('00000000-0000-0000-0000-000000000000'))).toBeTruthy();
+  });
+
+  it('should return true for undefined', () => {
+    expect(fn(undefined)).toBeTruthy();
+  });
+
+  it('should return false on invalid UUID strings', () => {
+    expect(fn('66666666-6666-6666-6666-66666666')).toBeFalsy();
+    expect(fn('garbage')).toBeFalsy();
+  });
+
+  it('should return false for a number', () => {
+    expect(fn(123)).toBeFalsy();
+  });
+
+  it('should return false for an object', () => {
+    expect(fn({})).toBeFalsy();
+  });
+
+  it('should return false for an array', () => {
+    expect(fn([])).toBeFalsy();
+  });
+});
+
+describe('models.queryParams.status', () => {
+  const fn = models.queryParams.status;
+
+  it('should return true for a string', () => {
+    expect(fn('this is a status')).toBeTruthy();
+  });
+
+  it('should return true for a string object', () => {
+    expect(fn(String('this is a status'))).toBeTruthy();
+  });
+
+  it('should return true for undefined', () => {
+    expect(fn(undefined)).toBeTruthy();
+  });
+
+  it('should return false for a number', () => {
+    expect(fn(123)).toBeFalsy();
+  });
+
+  it('should return false for an object', () => {
+    expect(fn({})).toBeFalsy();
+  });
+
+  it('should return false for an array', () => {
+    expect(fn([])).toBeFalsy();
+  });
+});
+
+describe('models.queryParams.tag', () => {
+  const fn = models.queryParams.tag;
+
+  it('should return true for a string', () => {
+    expect(fn('this is a tag')).toBeTruthy();
+  });
+
+  it('should return true for a string object', () => {
+    expect(fn(String('this is a tag'))).toBeTruthy();
+  });
+
+  it('should return true for undefined', () => {
+    expect(fn(undefined)).toBeTruthy();
+  });
+
+  it('should return false for a number', () => {
+    expect(fn(123)).toBeFalsy();
+  });
+
+  it('should return false for an object', () => {
+    expect(fn({})).toBeFalsy();
+  });
+
+  it('should return false for an array', () => {
+    expect(fn([])).toBeFalsy();
+  });
+});
+
+describe('models.queryParams.txId', () => {
+  const fn = models.queryParams.txId;
+
+  it('should return true for valid UUID strings', () => {
+    expect(fn('00000000-0000-0000-0000-000000000000')).toBeTruthy();
+    expect(fn('11111111-1111-1111-0111-111111111111')).toBeTruthy();
+    expect(fn('ac2b944a-c148-4dfe-8103-d4cdc6b0a79a')).toBeTruthy();
+    expect(fn('86a12b0d-6d7a-491c-a1fb-98db9543bf55')).toBeTruthy();
+  });
+
+  it('should return true for valid UUID string object', () => {
+    expect(fn(String('00000000-0000-0000-0000-000000000000'))).toBeTruthy();
+  });
+
+  it('should return true for undefined', () => {
+    expect(fn(undefined)).toBeTruthy();
+  });
+
+  it('should return false on invalid UUID strings', () => {
+    expect(fn('66666666-6666-6666-6666-66666666')).toBeFalsy();
+    expect(fn('garbage')).toBeFalsy();
+  });
+
+  it('should return false for a number', () => {
+    expect(fn(123)).toBeFalsy();
+  });
+
+  it('should return false for an object', () => {
+    expect(fn({})).toBeFalsy();
+  });
+
+  it('should return false for an array', () => {
+    expect(fn([])).toBeFalsy();
+  });
+});
+
+describe('validators.attachments', () => {
 
   it('should return empty error list for undefined attachments', async () => {
     const obj = {};
@@ -1373,7 +1302,7 @@ describe('attachments list', () => {
 
 });
 
-describe('email message', () => {
+describe('validators.email', () => {
 
   const goodEmail = {
     from: '"Email Sender" <email@sender.org>',
@@ -1584,7 +1513,7 @@ describe('email message', () => {
 
 });
 
-describe('email merge', () => {
+describe('validators.merge', () => {
 
   const goodMergeObject = () => {
     return {
@@ -1864,135 +1793,37 @@ describe('email merge', () => {
 
 });
 
-describe('queryParams.msgId', () => {
-  const fn = validators.queryParams.msgId;
+describe('validators.statusFetch', () => {
+  let param;
 
-  it('should return true for valid UUID strings', () => {
-    expect(fn('00000000-0000-0000-0000-000000000000')).toBeTruthy();
-    expect(fn('11111111-1111-1111-0111-111111111111')).toBeTruthy();
-    expect(fn('ac2b944a-c148-4dfe-8103-d4cdc6b0a79a')).toBeTruthy();
-    expect(fn('86a12b0d-6d7a-491c-a1fb-98db9543bf55')).toBeTruthy();
+  beforeEach(() => {
+    param = {
+      fields: 'createdTimestamp,delayTS,updatedTimestamp'
+    };
   });
 
-  it('should return true for valid UUID string object', () => {
-    expect(fn(String('00000000-0000-0000-0000-000000000000'))).toBeTruthy();
+  it('should return an empty error array when valid', () => {
+    const result = validators.statusFetch(param);
+
+    expect(result).toBeTruthy();
+    expect(Array.isArray(result)).toBeTruthy();
+    expect(result.length).toEqual(0);
   });
 
-  it('should return true for undefined', () => {
-    expect(fn(undefined)).toBeTruthy();
-  });
+  it('should return an error with validation error when invalid', () => {
+    param.msgId = 'garbage';
 
-  it('should return false on invalid UUID strings', () => {
-    expect(fn('66666666-6666-6666-6666-66666666')).toBeFalsy();
-    expect(fn('garbage')).toBeFalsy();
-  });
+    const result = validators.statusFetch(param);
 
-  it('should return false for a number', () => {
-    expect(fn(123)).toBeFalsy();
-  });
-
-  it('should return false for an object', () => {
-    expect(fn({})).toBeFalsy();
-  });
-
-  it('should return false for an array', () => {
-    expect(fn([])).toBeFalsy();
+    expect(result).toBeTruthy();
+    expect(Array.isArray(result)).toBeTruthy();
+    expect(result.length).toEqual(1);
+    expect(result[0].value).toMatch('garbage');
+    expect(result[0].message).toMatch('Invalid value `msgId`.');
   });
 });
 
-describe('queryParams.status', () => {
-  const fn = validators.queryParams.status;
-
-  it('should return true for a string', () => {
-    expect(fn('this is a status')).toBeTruthy();
-  });
-
-  it('should return true for a string object', () => {
-    expect(fn(String('this is a status'))).toBeTruthy();
-  });
-
-  it('should return true for undefined', () => {
-    expect(fn(undefined)).toBeTruthy();
-  });
-
-  it('should return false for a number', () => {
-    expect(fn(123)).toBeFalsy();
-  });
-
-  it('should return false for an object', () => {
-    expect(fn({})).toBeFalsy();
-  });
-
-  it('should return false for an array', () => {
-    expect(fn([])).toBeFalsy();
-  });
-});
-
-describe('queryParams.tag', () => {
-  const fn = validators.queryParams.tag;
-
-  it('should return true for a string', () => {
-    expect(fn('this is a tag')).toBeTruthy();
-  });
-
-  it('should return true for a string object', () => {
-    expect(fn(String('this is a tag'))).toBeTruthy();
-  });
-
-  it('should return true for undefined', () => {
-    expect(fn(undefined)).toBeTruthy();
-  });
-
-  it('should return false for a number', () => {
-    expect(fn(123)).toBeFalsy();
-  });
-
-  it('should return false for an object', () => {
-    expect(fn({})).toBeFalsy();
-  });
-
-  it('should return false for an array', () => {
-    expect(fn([])).toBeFalsy();
-  });
-});
-
-describe('queryParams.txId', () => {
-  const fn = validators.queryParams.txId;
-
-  it('should return true for valid UUID strings', () => {
-    expect(fn('00000000-0000-0000-0000-000000000000')).toBeTruthy();
-    expect(fn('11111111-1111-1111-0111-111111111111')).toBeTruthy();
-    expect(fn('ac2b944a-c148-4dfe-8103-d4cdc6b0a79a')).toBeTruthy();
-    expect(fn('86a12b0d-6d7a-491c-a1fb-98db9543bf55')).toBeTruthy();
-  });
-
-  it('should return true for valid UUID string object', () => {
-    expect(fn(String('00000000-0000-0000-0000-000000000000'))).toBeTruthy();
-  });
-
-  it('should return true for undefined', () => {
-    expect(fn(undefined)).toBeTruthy();
-  });
-
-  it('should return false on invalid UUID strings', () => {
-    expect(fn('66666666-6666-6666-6666-66666666')).toBeFalsy();
-    expect(fn('garbage')).toBeFalsy();
-  });
-
-  it('should return false for a number', () => {
-    expect(fn(123)).toBeFalsy();
-  });
-
-  it('should return false for an object', () => {
-    expect(fn({})).toBeFalsy();
-  });
-
-  it('should return false for an array', () => {
-    expect(fn([])).toBeFalsy();
-  });
-});
-
-describe('statusQuery', () => {
+describe('validators.statusQuery', () => {
   let query;
 
   beforeEach(() => {
@@ -2057,7 +1888,7 @@ describe('statusQuery', () => {
   });
 });
 
-describe('statusQueryFields', () => {
+describe('validators.searchQueryFields', () => {
   let query;
 
   beforeEach(() => {
@@ -2070,7 +1901,7 @@ describe('statusQueryFields', () => {
   });
 
   it('should return an empty error array when all valid', () => {
-    const result = validators.statusQueryFields(query);
+    const result = validators.searchQueryFields(query);
 
     expect(result).toBeTruthy();
     expect(Array.isArray(result)).toBeTruthy();
@@ -2080,7 +1911,7 @@ describe('statusQueryFields', () => {
   it('should return an error when msgId is invalid', () => {
     query.msgId = 'garbage';
 
-    const result = validators.statusQueryFields(query);
+    const result = validators.searchQueryFields(query);
 
     expect(result).toBeTruthy();
     expect(Array.isArray(result)).toBeTruthy();
@@ -2092,7 +1923,7 @@ describe('statusQueryFields', () => {
   it('should return an error when status is invalid', () => {
     query.status = [];
 
-    const result = validators.statusQueryFields(query);
+    const result = validators.searchQueryFields(query);
 
     expect(result).toBeTruthy();
     expect(Array.isArray(result)).toBeTruthy();
@@ -2104,7 +1935,7 @@ describe('statusQueryFields', () => {
   it('should return an error when tag is invalid', () => {
     query.tag = [];
 
-    const result = validators.statusQueryFields(query);
+    const result = validators.searchQueryFields(query);
 
     expect(result).toBeTruthy();
     expect(Array.isArray(result)).toBeTruthy();
@@ -2116,7 +1947,7 @@ describe('statusQueryFields', () => {
   it('should return an error when txId is invalid', () => {
     query.txId = 'garbage';
 
-    const result = validators.statusQueryFields(query);
+    const result = validators.searchQueryFields(query);
 
     expect(result).toBeTruthy();
     expect(Array.isArray(result)).toBeTruthy();
@@ -2126,7 +1957,7 @@ describe('statusQueryFields', () => {
   });
 
   it('should return multiple errors with multiple invalid values', () => {
-    const result = validators.statusQueryFields({
+    const result = validators.searchQueryFields({
       msgId: 'garbage',
       status: [],
       tag: [],
@@ -2137,4 +1968,207 @@ describe('statusQueryFields', () => {
     expect(Array.isArray(result)).toBeTruthy();
     expect(result.length).toEqual(4);
   });
+});
+
+describe('validatorUtils.isEmail', () => {
+
+  it('should return true for email address', () => {
+    const result = validatorUtils.isEmail('email@address.com');
+
+    expect(result).toBeTruthy();
+  });
+
+  it('should return true for email address with display name', () => {
+    const result = validatorUtils.isEmail('Email Address <email@address.com>');
+
+    expect(result).toBeTruthy();
+  });
+
+  it('should return false for non-email address value', () => {
+    const result = validatorUtils.isEmail('this is not an email');
+
+    expect(result).toBeFalsy();
+  });
+
+  it('should return false for empty value', () => {
+    const result = validatorUtils.isEmail('');
+
+    expect(result).toBeFalsy();
+  });
+
+  it('should return false for whitespace value', () => {
+    const result = validatorUtils.isEmail('            ');
+
+    expect(result).toBeFalsy();
+  });
+
+  it('should return false for undefined value', () => {
+    const result = validatorUtils.isEmail(undefined);
+
+    expect(result).toBeFalsy();
+  });
+
+  it('should return false for non-string value', () => {
+    const result = validatorUtils.isEmail(123);
+
+    expect(result).toBeFalsy();
+  });
+
+});
+
+describe('validatorUtils.isEmailList', () => {
+
+  it('should return true for array of email addresses', () => {
+    const list = ['email@address.com', 'email2@address2.com'];
+    const result = validatorUtils.isEmailList(list);
+
+    expect(result).toBeTruthy();
+  });
+
+  it('should return true for array of email addresses with display names', () => {
+    const list = ['Email Address <email@address.com>', 'Email Address II <email2@address2.com>'];
+    const result = validatorUtils.isEmailList(list);
+
+    expect(result).toBeTruthy();
+  });
+
+  it('should return true for array of email addresses, some with display names', () => {
+    const list = ['email@address.com', '"Email Address Jr." <email2@address2.com>'];
+    const result = validatorUtils.isEmailList(list);
+
+    expect(result).toBeTruthy();
+  });
+
+  it('should return true for an empty array', () => {
+    const list = [];
+    const result = validatorUtils.isEmailList(list);
+
+    expect(result).toBeTruthy();
+  });
+
+  it('should return false for non-array value', () => {
+    const result = validatorUtils.isEmailList({ field: 'value' });
+
+    expect(result).toBeFalsy();
+  });
+
+  it('should return false for string value', () => {
+    const result = validatorUtils.isEmailList('');
+
+    expect(result).toBeFalsy();
+  });
+
+  it('should return false for undefined value', () => {
+    const result = validatorUtils.isEmailList(undefined);
+
+    expect(result).toBeFalsy();
+  });
+
+});
+
+describe('validatorUtils.isInt', () => {
+
+  it('should return true for a int', () => {
+    const value = 123;
+    const result = validatorUtils.isInt(value);
+
+    expect(result).toBeTruthy();
+  });
+
+  it('should return true for a integer as string ', () => {
+    const value = '123456';
+    const result = validatorUtils.isInt(value);
+
+    expect(result).toBeTruthy();
+  });
+
+  it('should return true for a integer as string object ', () => {
+    const value = String(123456);
+    const result = validatorUtils.isInt(value);
+
+    expect(result).toBeTruthy();
+  });
+
+  it('should return false for a non-numeric string ', () => {
+    const value = 'abcdefg1234567';
+    const result = validatorUtils.isInt(value);
+
+    expect(result).toBeFalsy();
+  });
+
+  it('should return false for a float ', () => {
+    const value = 123.45;
+    const result = validatorUtils.isInt(value);
+
+    expect(result).toBeFalsy();
+  });
+
+  it('should return false for a float string ', () => {
+    const value = '123.45';
+    const result = validatorUtils.isInt(value);
+
+    expect(result).toBeFalsy();
+  });
+
+  it('should return false for an array', () => {
+    const result = validatorUtils.isInt([{ value: 123 }]);
+
+    expect(result).toBeFalsy();
+  });
+
+  it('should return false for a function', () => {
+    const value = x => {
+      return String(x);
+    };
+    const result = validatorUtils.isInt(value);
+
+    expect(result).toBeFalsy();
+  });
+
+});
+
+describe('validatorUtils.isString', () => {
+
+  it('should return true for a string', () => {
+    const value = 'this is a string';
+    const result = validatorUtils.isString(value);
+
+    expect(result).toBeTruthy();
+  });
+
+  it('should return true for a string object ', () => {
+    const value = String(123456);
+    const result = validatorUtils.isString(value);
+
+    expect(result).toBeTruthy();
+  });
+
+  it('should return false for a number ', () => {
+    const value = 123456;
+    const result = validatorUtils.isString(value);
+
+    expect(result).toBeFalsy();
+  });
+
+  it('should return false for a non-string object ', () => {
+    const result = validatorUtils.isString({ value: 'string' });
+
+    expect(result).toBeFalsy();
+  });
+
+  it('should return false for an array', () => {
+    const result = validatorUtils.isString([{ value: 'string' }]);
+
+    expect(result).toBeFalsy();
+  });
+
+  it('should return false for a function', () => {
+    const value = x => {
+      return String(x);
+    };
+    const result = validatorUtils.isString(value);
+
+    expect(result).toBeFalsy();
+  });
+
 });

--- a/app/tests/unit/components/validators.spec.js
+++ b/app/tests/unit/components/validators.spec.js
@@ -1164,7 +1164,7 @@ describe('validators.attachments', () => {
   it('should return empty error list for undefined attachments', async () => {
     const obj = {};
     const result = await validators.attachments(obj);
-    expect(result.length).toBe(0);
+    expect(result).toHaveLength(0);
   });
 
   it('should return empty error list for attachments as array', async () => {
@@ -1172,7 +1172,7 @@ describe('validators.attachments', () => {
       attachments: []
     };
     const result = await validators.attachments(obj);
-    expect(result.length).toBe(0);
+    expect(result).toHaveLength(0);
   });
 
   it('should return error list when attachments is not array', async () => {
@@ -1180,7 +1180,7 @@ describe('validators.attachments', () => {
       attachments: {}
     };
     const result = await validators.attachments(obj);
-    expect(result.length).toBe(1);
+    expect(result).toHaveLength(1);
   });
 
   it('should return empty error list for valid attachments', async () => {
@@ -1194,7 +1194,7 @@ describe('validators.attachments', () => {
         }]
     };
     const result = await validators.attachments(obj);
-    expect(result.length).toBe(0);
+    expect(result).toHaveLength(0);
   });
 
   it('should return an error for each attachment that is too large', async () => {
@@ -1206,7 +1206,7 @@ describe('validators.attachments', () => {
       ]
     };
     const result = await validators.attachments(obj, realSmallFile.size);
-    expect(result.length).toBe(2);
+    expect(result).toHaveLength(2);
   });
 
   it('should return an error when attachment filename key not provided', async () => {
@@ -1216,7 +1216,7 @@ describe('validators.attachments', () => {
       ]
     };
     const result = await validators.attachments(obj);
-    expect(result.length).toBe(1);
+    expect(result).toHaveLength(1);
     expect(result[0].message).toMatch(/filename/);
   });
 
@@ -1227,7 +1227,7 @@ describe('validators.attachments', () => {
       ]
     };
     const result = await validators.attachments(obj);
-    expect(result.length).toBe(1);
+    expect(result).toHaveLength(1);
     expect(result[0].message).toMatch(/filename/);
   });
 
@@ -1243,7 +1243,7 @@ describe('validators.attachments', () => {
       ]
     };
     const result = await validators.attachments(obj);
-    expect(result.length).toBe(1);
+    expect(result).toHaveLength(1);
     expect(result[0].message).toMatch(/encoding/);
   });
 
@@ -1254,7 +1254,7 @@ describe('validators.attachments', () => {
       ]
     };
     const result = await validators.attachments(obj);
-    expect(result.length).toBe(0);
+    expect(result).toHaveLength(0);
   });
 
   it('should return an error when attachment contentType value is bad', async () => {
@@ -1264,7 +1264,7 @@ describe('validators.attachments', () => {
       ]
     };
     const result = await validators.attachments(obj);
-    expect(result.length).toBe(1);
+    expect(result).toHaveLength(1);
     expect(result[0].message).toMatch(/contentType/);
   });
 
@@ -1275,7 +1275,7 @@ describe('validators.attachments', () => {
       ]
     };
     const result = await validators.attachments(obj);
-    expect(result.length).toBe(0);
+    expect(result).toHaveLength(0);
   });
 
   it('should return an error when attachment has no content', async () => {
@@ -1285,7 +1285,7 @@ describe('validators.attachments', () => {
       ]
     };
     const result = await validators.attachments(obj, realSmallFile.size);
-    expect(result.length).toBe(1);
+    expect(result).toHaveLength(1);
     expect(result[0].message).toMatch(/content/);
   });
 
@@ -1296,7 +1296,7 @@ describe('validators.attachments', () => {
       ]
     };
     const result = await validators.attachments(obj, realSmallFile.size);
-    expect(result.length).toBe(1);
+    expect(result).toHaveLength(1);
     expect(result[0].message).toMatch(/content/);
   });
 
@@ -1328,7 +1328,7 @@ describe('validators.email', () => {
   it('should return empty error list for a complete and valid email message', async () => {
     const obj = { ...goodEmail };
     const result = await validators.email(obj);
-    expect(result.length).toBe(0);
+    expect(result).toHaveLength(0);
   });
 
   it('should return an error when email message has invalid attachment', async () => {
@@ -1336,7 +1336,7 @@ describe('validators.email', () => {
     obj.attachments = [{ encoding: 'base64', contentType: 'application/pdf', content: realSmallFile.content }];
 
     const result = await validators.email(obj);
-    expect(result.length).toBe(1);
+    expect(result).toHaveLength(1);
     expect(result[0].message).toMatch(/Attachments/);
     expect(result[0].message).toMatch(/filename/);
   });
@@ -1345,7 +1345,7 @@ describe('validators.email', () => {
     const obj = { ...goodEmail };
     delete obj.from;
     const result = await validators.email(obj);
-    expect(result.length).toBe(1);
+    expect(result).toHaveLength(1);
     expect(result[0].message).toMatch(/from/);
   });
 
@@ -1353,7 +1353,7 @@ describe('validators.email', () => {
     const obj = { ...goodEmail };
     obj.from = 'not a good from';
     const result = await validators.email(obj);
-    expect(result.length).toBe(1);
+    expect(result).toHaveLength(1);
     expect(result[0].message).toMatch(/from/);
   });
 
@@ -1361,7 +1361,7 @@ describe('validators.email', () => {
     const obj = { ...goodEmail };
     delete obj.to;
     const result = await validators.email(obj);
-    expect(result.length).toBe(1);
+    expect(result).toHaveLength(1);
     expect(result[0].message).toMatch(/to/);
   });
 
@@ -1369,7 +1369,7 @@ describe('validators.email', () => {
     const obj = { ...goodEmail };
     obj.to = 'not a good from';
     const result = await validators.email(obj);
-    expect(result.length).toBe(1);
+    expect(result).toHaveLength(1);
     expect(result[0].message).toMatch(/to/);
   });
 
@@ -1377,14 +1377,14 @@ describe('validators.email', () => {
     const obj = { ...goodEmail };
     delete obj.cc;
     const result = await validators.email(obj);
-    expect(result.length).toBe(0);
+    expect(result).toHaveLength(0);
   });
 
   it('should return an error when email message invalid cc', async () => {
     const obj = { ...goodEmail };
     obj.cc = 'not a good to';
     const result = await validators.email(obj);
-    expect(result.length).toBe(1);
+    expect(result).toHaveLength(1);
     expect(result[0].message).toMatch(/cc/);
   });
 
@@ -1392,14 +1392,14 @@ describe('validators.email', () => {
     const obj = { ...goodEmail };
     delete obj.bcc;
     const result = await validators.email(obj);
-    expect(result.length).toBe(0);
+    expect(result).toHaveLength(0);
   });
 
   it('should return an error when email message invalid bcc', async () => {
     const obj = { ...goodEmail };
     obj.bcc = 'not a good bcc';
     const result = await validators.email(obj);
-    expect(result.length).toBe(1);
+    expect(result).toHaveLength(1);
     expect(result[0].message).toMatch(/bcc/);
   });
 
@@ -1407,7 +1407,7 @@ describe('validators.email', () => {
     const obj = { ...goodEmail };
     delete obj.subject;
     const result = await validators.email(obj);
-    expect(result.length).toBe(1);
+    expect(result).toHaveLength(1);
     expect(result[0].message).toMatch(/subject/);
   });
 
@@ -1415,7 +1415,7 @@ describe('validators.email', () => {
     const obj = { ...goodEmail };
     obj.subject = 123;
     const result = await validators.email(obj);
-    expect(result.length).toBe(1);
+    expect(result).toHaveLength(1);
     expect(result[0].message).toMatch(/subject/);
   });
 
@@ -1423,7 +1423,7 @@ describe('validators.email', () => {
     const obj = { ...goodEmail };
     delete obj.bodyType;
     const result = await validators.email(obj);
-    expect(result.length).toBe(1);
+    expect(result).toHaveLength(1);
     expect(result[0].message).toMatch(/bodyType/);
   });
 
@@ -1431,7 +1431,7 @@ describe('validators.email', () => {
     const obj = { ...goodEmail };
     obj.bodyType = 'xhtmlx';
     const result = await validators.email(obj);
-    expect(result.length).toBe(1);
+    expect(result).toHaveLength(1);
     expect(result[0].message).toMatch(/bodyType/);
   });
 
@@ -1439,7 +1439,7 @@ describe('validators.email', () => {
     const obj = { ...goodEmail };
     delete obj.body;
     const result = await validators.email(obj);
-    expect(result.length).toBe(1);
+    expect(result).toHaveLength(1);
     expect(result[0].message).toMatch(/body/);
   });
 
@@ -1447,7 +1447,7 @@ describe('validators.email', () => {
     const obj = { ...goodEmail };
     obj.body = {};
     const result = await validators.email(obj);
-    expect(result.length).toBe(1);
+    expect(result).toHaveLength(1);
     expect(result[0].message).toMatch(/body/);
   });
 
@@ -1455,14 +1455,14 @@ describe('validators.email', () => {
     const obj = { ...goodEmail };
     delete obj.encoding;
     const result = await validators.email(obj);
-    expect(result.length).toBe(0);
+    expect(result).toHaveLength(0);
   });
 
   it('should return an error when email message invalid encoding', async () => {
     const obj = { ...goodEmail };
     obj.encoding = 'not a good encoding';
     const result = await validators.email(obj);
-    expect(result.length).toBe(1);
+    expect(result).toHaveLength(1);
     expect(result[0].message).toMatch(/encoding/);
   });
 
@@ -1470,14 +1470,14 @@ describe('validators.email', () => {
     const obj = { ...goodEmail };
     delete obj.priority;
     const result = await validators.email(obj);
-    expect(result.length).toBe(0);
+    expect(result).toHaveLength(0);
   });
 
   it('should return an error when email message invalid priority', async () => {
     const obj = { ...goodEmail };
     obj.priority = 'not a good priority';
     const result = await validators.email(obj);
-    expect(result.length).toBe(1);
+    expect(result).toHaveLength(1);
     expect(result[0].message).toMatch(/priority/);
   });
 
@@ -1485,14 +1485,14 @@ describe('validators.email', () => {
     const obj = { ...goodEmail };
     delete obj.tag;
     const result = await validators.email(obj);
-    expect(result.length).toBe(0);
+    expect(result).toHaveLength(0);
   });
 
   it('should return an error when email message invalid tag', async () => {
     const obj = { ...goodEmail };
     obj.tag = ['not a good tag'];
     const result = await validators.email(obj);
-    expect(result.length).toBe(1);
+    expect(result).toHaveLength(1);
     expect(result[0].message).toMatch(/tag/);
   });
 
@@ -1500,14 +1500,14 @@ describe('validators.email', () => {
     const obj = { ...goodEmail };
     delete obj.delayTS;
     const result = await validators.email(obj);
-    expect(result.length).toBe(0);
+    expect(result).toHaveLength(0);
   });
 
   it('should return an error when email message invalid delayTS', async () => {
     const obj = { ...goodEmail };
     obj.delayTS = 'not a good delayTS';
     const result = await validators.email(obj);
-    expect(result.length).toBe(1);
+    expect(result).toHaveLength(1);
     expect(result[0].message).toMatch(/delayTS/);
   });
 
@@ -1557,7 +1557,7 @@ describe('validators.merge', () => {
   it('should return empty error list for a complete and valid merge message', async () => {
     const obj = goodMergeObject();
     const result = await validators.merge(obj);
-    expect(result.length).toBe(0);
+    expect(result).toHaveLength(0);
   });
 
   it('should return an error when merge has invalid attachment', async () => {
@@ -1565,7 +1565,7 @@ describe('validators.merge', () => {
     obj.attachments = [{ encoding: 'base64', contentType: 'application/pdf', content: realSmallFile.content }];
 
     const result = await validators.merge(obj);
-    expect(result.length).toBe(1);
+    expect(result).toHaveLength(1);
     expect(result[0].message).toMatch(/Attachments/);
     expect(result[0].message).toMatch(/filename/);
   });
@@ -1574,7 +1574,7 @@ describe('validators.merge', () => {
     const obj = goodMergeObject();
     delete obj.from;
     const result = await validators.merge(obj);
-    expect(result.length).toBe(1);
+    expect(result).toHaveLength(1);
     expect(result[0].message).toMatch(/from/);
   });
 
@@ -1582,7 +1582,7 @@ describe('validators.merge', () => {
     const obj = goodMergeObject();
     obj.from = 'not a good from';
     const result = await validators.merge(obj);
-    expect(result.length).toBe(1);
+    expect(result).toHaveLength(1);
     expect(result[0].message).toMatch(/from/);
   });
 
@@ -1590,7 +1590,7 @@ describe('validators.merge', () => {
     const obj = goodMergeObject();
     delete obj.subject;
     const result = await validators.merge(obj);
-    expect(result.length).toBe(1);
+    expect(result).toHaveLength(1);
     expect(result[0].message).toMatch(/subject/);
   });
 
@@ -1598,7 +1598,7 @@ describe('validators.merge', () => {
     const obj = goodMergeObject();
     obj.subject = 123;
     const result = await validators.merge(obj);
-    expect(result.length).toBe(1);
+    expect(result).toHaveLength(1);
     expect(result[0].message).toMatch(/subject/);
   });
 
@@ -1606,7 +1606,7 @@ describe('validators.merge', () => {
     const obj = goodMergeObject();
     delete obj.bodyType;
     const result = await validators.merge(obj);
-    expect(result.length).toBe(1);
+    expect(result).toHaveLength(1);
     expect(result[0].message).toMatch(/bodyType/);
   });
 
@@ -1614,7 +1614,7 @@ describe('validators.merge', () => {
     const obj = goodMergeObject();
     obj.bodyType = 'xhtmlx';
     const result = await validators.merge(obj);
-    expect(result.length).toBe(1);
+    expect(result).toHaveLength(1);
     expect(result[0].message).toMatch(/bodyType/);
   });
 
@@ -1622,7 +1622,7 @@ describe('validators.merge', () => {
     const obj = goodMergeObject();
     delete obj.body;
     const result = await validators.merge(obj);
-    expect(result.length).toBe(1);
+    expect(result).toHaveLength(1);
     expect(result[0].message).toMatch(/body/);
   });
 
@@ -1630,7 +1630,7 @@ describe('validators.merge', () => {
     const obj = goodMergeObject();
     obj.body = {};
     const result = await validators.merge(obj);
-    expect(result.length).toBe(1);
+    expect(result).toHaveLength(1);
     expect(result[0].message).toMatch(/body/);
   });
 
@@ -1638,14 +1638,14 @@ describe('validators.merge', () => {
     const obj = goodMergeObject();
     delete obj.encoding;
     const result = await validators.merge(obj);
-    expect(result.length).toBe(0);
+    expect(result).toHaveLength(0);
   });
 
   it('should return an error when merge has invalid encoding', async () => {
     const obj = goodMergeObject();
     obj.encoding = 'not a good encoding';
     const result = await validators.merge(obj);
-    expect(result.length).toBe(1);
+    expect(result).toHaveLength(1);
     expect(result[0].message).toMatch(/encoding/);
   });
 
@@ -1653,14 +1653,14 @@ describe('validators.merge', () => {
     const obj = goodMergeObject();
     delete obj.priority;
     const result = await validators.merge(obj);
-    expect(result.length).toBe(0);
+    expect(result).toHaveLength(0);
   });
 
   it('should return an error when merge has invalid priority', async () => {
     const obj = goodMergeObject();
     obj.priority = 'not a good priority';
     const result = await validators.merge(obj);
-    expect(result.length).toBe(1);
+    expect(result).toHaveLength(1);
     expect(result[0].message).toMatch(/priority/);
   });
 
@@ -1669,7 +1669,7 @@ describe('validators.merge', () => {
     delete obj.contexts;
 
     const result = await validators.merge(obj);
-    expect(result.length).toBe(1);
+    expect(result).toHaveLength(1);
     expect(result[0].message).toMatch(/Contexts/);
   });
 
@@ -1678,7 +1678,7 @@ describe('validators.merge', () => {
     obj.contexts = {};
 
     const result = await validators.merge(obj);
-    expect(result.length).toBe(1);
+    expect(result).toHaveLength(1);
     expect(result[0].message).toMatch(/contexts/);
     expect(result[0].message).toMatch(/array/);
   });
@@ -1687,7 +1687,7 @@ describe('validators.merge', () => {
     const obj = goodMergeObject();
     delete obj.contexts[0].to;
     const result = await validators.merge(obj);
-    expect(result.length).toBe(1);
+    expect(result).toHaveLength(1);
     expect(result[0].message).toMatch(/Contexts/);
     expect(result[0].message).toMatch(/to/);
   });
@@ -1696,7 +1696,7 @@ describe('validators.merge', () => {
     const obj = goodMergeObject();
     obj.contexts[0].to = 'not a good value';
     const result = await validators.merge(obj);
-    expect(result.length).toBe(1);
+    expect(result).toHaveLength(1);
     expect(result[0].message).toMatch(/Contexts/);
     expect(result[0].message).toMatch(/to/);
   });
@@ -1705,14 +1705,14 @@ describe('validators.merge', () => {
     const obj = goodMergeObject();
     delete obj.contexts[0].cc;
     const result = await validators.merge(obj);
-    expect(result.length).toBe(0);
+    expect(result).toHaveLength(0);
   });
 
   it('should return an error when merges contexts invalid cc', async () => {
     const obj = goodMergeObject();
     obj.contexts[0].cc = 'not a good value';
     const result = await validators.merge(obj);
-    expect(result.length).toBe(1);
+    expect(result).toHaveLength(1);
     expect(result[0].message).toMatch(/Contexts/);
     expect(result[0].message).toMatch(/cc/);
   });
@@ -1721,14 +1721,14 @@ describe('validators.merge', () => {
     const obj = goodMergeObject();
     delete obj.contexts[0].bcc;
     const result = await validators.merge(obj);
-    expect(result.length).toBe(0);
+    expect(result).toHaveLength(0);
   });
 
   it('should return an error when merges contexts invalid bcc', async () => {
     const obj = goodMergeObject();
     obj.contexts[0].bcc = 'not a good value';
     const result = await validators.merge(obj);
-    expect(result.length).toBe(1);
+    expect(result).toHaveLength(1);
     expect(result[0].message).toMatch(/Contexts/);
     expect(result[0].message).toMatch(/bcc/);
   });
@@ -1737,14 +1737,14 @@ describe('validators.merge', () => {
     const obj = goodMergeObject();
     delete obj.contexts[0].tag;
     const result = await validators.merge(obj);
-    expect(result.length).toBe(0);
+    expect(result).toHaveLength(0);
   });
 
   it('should return an error when merges contexts invalid tag', async () => {
     const obj = goodMergeObject();
     obj.contexts[0].tag = ['tag', 'tag'];
     const result = await validators.merge(obj);
-    expect(result.length).toBe(1);
+    expect(result).toHaveLength(1);
     expect(result[0].message).toMatch(/Contexts/);
     expect(result[0].message).toMatch(/tag/);
   });
@@ -1753,14 +1753,14 @@ describe('validators.merge', () => {
     const obj = goodMergeObject();
     delete obj.contexts[0].delayTS;
     const result = await validators.merge(obj);
-    expect(result.length).toBe(0);
+    expect(result).toHaveLength(0);
   });
 
   it('should return an error when email message invalid delayTS', async () => {
     const obj = goodMergeObject();
     obj.contexts[0].delayTS = 'not a good delayTS';
     const result = await validators.merge(obj);
-    expect(result.length).toBe(1);
+    expect(result).toHaveLength(1);
     expect(result[0].message).toMatch(/delayTS/);
   });
 
@@ -1768,7 +1768,7 @@ describe('validators.merge', () => {
     const obj = goodMergeObject();
     delete obj.contexts[0].context;
     const result = await validators.merge(obj);
-    expect(result.length).toBe(1);
+    expect(result).toHaveLength(1);
     expect(result[0].message).toMatch(/Contexts/);
     expect(result[0].message).toMatch(/context/);
   });
@@ -1786,7 +1786,7 @@ describe('validators.merge', () => {
     };
     obj.contexts.push(badContext);
     const result = await validators.merge(obj);
-    expect(result.length).toBe(1);
+    expect(result).toHaveLength(1);
     expect(result[0].message).toMatch(/Contexts/);
     expect(result[0].message).toMatch(/alphanumeric/);
   });

--- a/app/tests/unit/components/validators.spec.js
+++ b/app/tests/unit/components/validators.spec.js
@@ -2024,6 +2024,16 @@ describe('statusQuery', () => {
     expect(result.length).toEqual(0);
   });
 
+  it('should return an error with some validation errors', () => {
+    query.txId = 'garbage';
+
+    const result = validators.statusQuery(query);
+
+    expect(result).toBeTruthy();
+    expect(Array.isArray(result)).toBeTruthy();
+    expect(result.length).toEqual(1);
+  });
+
   it('should return an error when all parameters are missing', () => {
     const result = validators.statusQuery({});
 
@@ -2031,7 +2041,7 @@ describe('statusQuery', () => {
     expect(Array.isArray(result)).toBeTruthy();
     expect(result.length).toEqual(1);
     expect(result[0].message).toMatch(/At least one of/);
-    expect(result[0].value).toMatch(/params/);
+    expect(result[0].value).toMatch('params');
   });
 
   it('should return an error with invalid field content', () => {
@@ -2043,7 +2053,7 @@ describe('statusQuery', () => {
     expect(Array.isArray(result)).toBeTruthy();
     expect(result.length).toEqual(1);
     expect(result[0].message).toMatch(/Value.*is not one of/);
-    expect(result[0].value).toMatch(/fields/);
+    expect(result[0].value).toMatch('fields');
   });
 });
 

--- a/app/tests/unit/components/validators.spec.js
+++ b/app/tests/unit/components/validators.spec.js
@@ -1863,3 +1863,131 @@ describe('email merge', () => {
   });
 
 });
+
+describe('queryParams.msgId', () => {
+  const fn = validators.queryParams.msgId;
+
+  it('should return true for valid UUID strings', () => {
+    expect(fn('00000000-0000-0000-0000-000000000000')).toBeTruthy();
+    expect(fn('11111111-1111-1111-0111-111111111111')).toBeTruthy();
+    expect(fn('ac2b944a-c148-4dfe-8103-d4cdc6b0a79a')).toBeTruthy();
+    expect(fn('86a12b0d-6d7a-491c-a1fb-98db9543bf55')).toBeTruthy();
+  });
+
+  it('should return true for valid UUID string object', () => {
+    expect(fn(String('00000000-0000-0000-0000-000000000000'))).toBeTruthy();
+  });
+
+  it('should return true for undefined', () => {
+    expect(fn(undefined)).toBeTruthy();
+  });
+
+  it('should return false on invalid UUID strings', () => {
+    expect(fn('66666666-6666-6666-6666-66666666')).toBeFalsy();
+    expect(fn('garbage')).toBeFalsy();
+  });
+
+  it('should return false for a number', () => {
+    expect(fn(123)).toBeFalsy();
+  });
+
+  it('should return false for an object', () => {
+    expect(fn({})).toBeFalsy();
+  });
+
+  it('should return false for an array', () => {
+    expect(fn([])).toBeFalsy();
+  });
+});
+
+describe('queryParams.status', () => {
+  const fn = validators.queryParams.status;
+
+  it('should return true for a string', () => {
+    expect(fn('this is a status')).toBeTruthy();
+  });
+
+  it('should return true for a string object', () => {
+    expect(fn(String('this is a status'))).toBeTruthy();
+  });
+
+  it('should return true for undefined', () => {
+    expect(fn(undefined)).toBeTruthy();
+  });
+
+  it('should return false for a number', () => {
+    expect(fn(123)).toBeFalsy();
+  });
+
+  it('should return false for an object', () => {
+    expect(fn({})).toBeFalsy();
+  });
+
+  it('should return false for an array', () => {
+    expect(fn([])).toBeFalsy();
+  });
+});
+
+describe('queryParams.tag', () => {
+  const fn = validators.queryParams.tag;
+
+  it('should return true for a string', () => {
+    expect(fn('this is a tag')).toBeTruthy();
+  });
+
+  it('should return true for a string object', () => {
+    expect(fn(String('this is a tag'))).toBeTruthy();
+  });
+
+  it('should return true for undefined', () => {
+    expect(fn(undefined)).toBeTruthy();
+  });
+
+  it('should return false for a number', () => {
+    expect(fn(123)).toBeFalsy();
+  });
+
+  it('should return false for an object', () => {
+    expect(fn({})).toBeFalsy();
+  });
+
+  it('should return false for an array', () => {
+    expect(fn([])).toBeFalsy();
+  });
+});
+
+describe('queryParams.txId', () => {
+  const fn = validators.queryParams.txId;
+
+  it('should return true for valid UUID strings', () => {
+    expect(fn('00000000-0000-0000-0000-000000000000')).toBeTruthy();
+    expect(fn('11111111-1111-1111-0111-111111111111')).toBeTruthy();
+    expect(fn('ac2b944a-c148-4dfe-8103-d4cdc6b0a79a')).toBeTruthy();
+    expect(fn('86a12b0d-6d7a-491c-a1fb-98db9543bf55')).toBeTruthy();
+  });
+
+  it('should return true for valid UUID string object', () => {
+    expect(fn(String('00000000-0000-0000-0000-000000000000'))).toBeTruthy();
+  });
+
+  it('should return true for undefined', () => {
+    expect(fn(undefined)).toBeTruthy();
+  });
+
+  it('should return false on invalid UUID strings', () => {
+    expect(fn('66666666-6666-6666-6666-66666666')).toBeFalsy();
+    expect(fn('garbage')).toBeFalsy();
+  });
+
+  it('should return false for a number', () => {
+    expect(fn(123)).toBeFalsy();
+  });
+
+  it('should return false for an object', () => {
+    expect(fn({})).toBeFalsy();
+  });
+
+  it('should return false for an array', () => {
+    expect(fn([])).toBeFalsy();
+  });
+});

--- a/app/tests/unit/routes/v1/email.spec.js
+++ b/app/tests/unit/routes/v1/email.spec.js
@@ -12,8 +12,23 @@ const app = helper.expressHelper(basePath, router);
 jest.mock('../../../../src/services/chesSvc');
 
 describe(`POST ${basePath}`, () => {
+  const spy = ChesService.prototype.sendEmail;
+  let body;
+
+  beforeEach(() => {
+    body = {
+      bodyType: 'text',
+      body: 'body',
+      delayTS: 1,
+      from: 'email@email.com',
+      to: ['email@email.com'],
+      subject: 'subject',
+      tag: 'tag'
+    };
+  });
+
   afterEach(() => {
-    ChesService.prototype.sendEmail.mockClear();
+    spy.mockClear();
   });
 
   it('should yield a validation error', async () => {
@@ -23,45 +38,35 @@ describe(`POST ${basePath}`, () => {
     expect(response.body).toBeTruthy();
     expect(response.body.detail).toMatch('Validation failed');
     expect(response.body.errors).toHaveLength(5);
+    expect(spy).toHaveBeenCalledTimes(0);
   });
 
   it('should push a message and yield an Ethereal url', async () => {
-    ChesService.prototype.sendEmail.mockImplementation(() => {
+    delete body.delayTS;
+    delete body.tag;
+    spy.mockImplementation(() => {
       return 'https://example.com';
     });
 
     const response = await request(app).post(`${basePath}`)
-      .query('devMode=true')
-      .send({
-        bodyType: 'text',
-        body: 'body',
-        from: 'email@email.com',
-        to: ['email@email.com'],
-        subject: 'subject'
-      });
+      .query('devMode=true').send(body);
 
     expect(response.statusCode).toBe(201);
     expect(response.body).toBeTruthy();
     expect(response.body).toMatch('https://example.com');
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith(undefined, body, true);
   });
 
   it('should queue a message and yield an transaction response', async () => {
-    ChesService.prototype.sendEmail.mockImplementation(async (client, message) => {
+    spy.mockImplementation(async (client, message) => {
       return {
         txId: 'asdfasdfadsf',
         messages: [{ msgId: 'qwerqwerqwerw', to: message.to }]
       };
     });
 
-    const response = await request(app).post(`${basePath}`).send({
-      bodyType: 'text',
-      body: 'body',
-      delayTS: 1,
-      from: 'email@email.com',
-      to: ['email@email.com'],
-      subject: 'subject',
-      tag: 'tag'
-    });
+    const response = await request(app).post(`${basePath}`).send(body);
 
     expect(response.statusCode).toBe(201);
     expect(response.body).toBeTruthy();
@@ -70,26 +75,22 @@ describe(`POST ${basePath}`, () => {
     expect(response.body.messages).toHaveLength(1);
     expect(response.body.messages[0].to).toHaveLength(1);
     expect(response.body.messages[0].to[0]).toMatch('email@email.com');
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith(undefined, body, false);
   });
 
   it('should fail gracefully when an error occurs', async () => {
     const errorMsg = 'error';
-    ChesService.prototype.sendEmail.mockImplementation(() => {
+    spy.mockImplementation(() => {
       throw new Error(errorMsg);
     });
 
-    const response = await request(app).post(`${basePath}`).send({
-      bodyType: 'text',
-      body: 'body',
-      delayTS: 1,
-      from: 'email@email.com',
-      to: ['email@email.com'],
-      subject: 'subject',
-      tag: 'tag'
-    });
+    const response = await request(app).post(`${basePath}`).send(body);
 
     expect(response.statusCode).toBe(500);
     expect(response.body).toBeTruthy();
     expect(response.body.details).toBe(errorMsg);
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith(undefined, body, false);
   });
 });

--- a/app/tests/unit/routes/v1/email.spec.js
+++ b/app/tests/unit/routes/v1/email.spec.js
@@ -88,8 +88,6 @@ describe(`POST ${basePath}`, () => {
       tag: 'tag'
     });
 
-    console.log(response.body);
-
     expect(response.statusCode).toBe(500);
     expect(response.body).toBeTruthy();
     expect(response.body.details).toBe(errorMsg);

--- a/app/tests/unit/routes/v1/email.spec.js
+++ b/app/tests/unit/routes/v1/email.spec.js
@@ -3,28 +3,19 @@ const request = require('supertest');
 const helper = require('../../../common/helper');
 const router = require('../../../../src/routes/v1/email');
 
+const ChesService = require('../../../../src/services/chesSvc');
+
 // Simple Express Server
 const basePath = '/api/v1/email';
 const app = helper.expressHelper(basePath, router);
 
-jest.mock('../../../../src/services/chesSvc', () => {
-  return jest.fn().mockImplementation(() => {
-    return {
-      sendEmail: async (client, message, ethereal) => {
-        if (ethereal) {
-          return 'https://example.com';
-        } else {
-          return {
-            txId: 'asdfasdfadsf',
-            messages: [{ msgId: 'qwerqwerqwerw', to: message.to }]
-          };
-        }
-      }
-    };
-  });
-});
+jest.mock('../../../../src/services/chesSvc');
 
 describe(`POST ${basePath}`, () => {
+  afterEach(() => {
+    ChesService.prototype.sendEmail.mockClear();
+  });
+
   it('should yield a validation error', async () => {
     const response = await request(app).post(`${basePath}`);
 
@@ -35,6 +26,10 @@ describe(`POST ${basePath}`, () => {
   });
 
   it('should push a message and yield an Ethereal url', async () => {
+    ChesService.prototype.sendEmail.mockImplementation(() => {
+      return 'https://example.com';
+    });
+
     const response = await request(app).post(`${basePath}`)
       .query('devMode=true')
       .send({
@@ -51,6 +46,12 @@ describe(`POST ${basePath}`, () => {
   });
 
   it('should queue a message and yield an transaction response', async () => {
+    ChesService.prototype.sendEmail.mockImplementation(async (client, message) => {
+      return {
+        txId: 'asdfasdfadsf',
+        messages: [{ msgId: 'qwerqwerqwerw', to: message.to }]
+      };
+    });
 
     const response = await request(app).post(`${basePath}`).send({
       bodyType: 'text',
@@ -69,7 +70,28 @@ describe(`POST ${basePath}`, () => {
     expect(response.body.messages).toHaveLength(1);
     expect(response.body.messages[0].to).toHaveLength(1);
     expect(response.body.messages[0].to[0]).toMatch('email@email.com');
-
   });
 
+  it('should fail gracefully when an error occurs', async () => {
+    const errorMsg = 'error';
+    ChesService.prototype.sendEmail.mockImplementation(() => {
+      throw new Error(errorMsg);
+    });
+
+    const response = await request(app).post(`${basePath}`).send({
+      bodyType: 'text',
+      body: 'body',
+      delayTS: 1,
+      from: 'email@email.com',
+      to: ['email@email.com'],
+      subject: 'subject',
+      tag: 'tag'
+    });
+
+    console.log(response.body);
+
+    expect(response.statusCode).toBe(500);
+    expect(response.body).toBeTruthy();
+    expect(response.body.details).toBe(errorMsg);
+  });
 });

--- a/app/tests/unit/routes/v1/merge.spec.js
+++ b/app/tests/unit/routes/v1/merge.spec.js
@@ -20,68 +20,60 @@ const contexts = [
 jest.mock('../../../../src/services/chesSvc');
 
 describe(`POST ${basePath}`, () => {
+  const spy = ChesService.prototype.sendEmailMerge;
+  let body;
+
+  beforeEach(() => {
+    body = {
+      bodyType: 'text',
+      body: 'body',
+      contexts: contexts,
+      from: 'email@email.com',
+      subject: 'subject'
+    };
+  });
+
   afterEach(() => {
-    ChesService.prototype.sendEmailMerge.mockClear();
+    spy.mockClear();
   });
 
   it('should yield a validation error for to field', async () => {
-    const response = await request(app).post(`${basePath}`).send({
-      bodyType: 'text',
-      body: 'body',
-      from: 'email@email.com',
-      subject: 'subject',
-      contexts: [
-        {
-          to: undefined,
-          context: { good: 'bad' }
-        }]
-    });
+    body.contexts = [{ to: undefined, context: { good: 'bad' }}];
+    const response = await request(app).post(`${basePath}`).send(body);
 
     expect(response.statusCode).toBe(422);
     expect(response.body).toBeTruthy();
     expect(response.body.detail).toMatch('Validation failed');
     expect(response.body.errors).toHaveLength(1);
+    expect(spy).toHaveBeenCalledTimes(0);
   });
 
   it('should yield a validation error for context field', async () => {
-    const response = await request(app).post(`${basePath}`).send({
-      bodyType: 'text',
-      body: 'body',
-      from: 'email@email.com',
-      subject: 'subject',
-      contexts: [
-        {
-          to: ['email@email.com'],
-          context: 'undefined'
-        }]
-    });
+    body.contexts = [{ to: ['email@email.com'], context: 'undefined' }];
+    const response = await request(app).post(`${basePath}`).send(body);
 
     expect(response.statusCode).toBe(422);
     expect(response.body).toBeTruthy();
     expect(response.body.detail).toMatch('Validation failed');
     expect(response.body.errors).toHaveLength(1);
+    expect(spy).toHaveBeenCalledTimes(0);
   });
 
   it('should push a message and yield an Ethereal url', async () => {
-    ChesService.prototype.sendEmailMerge.mockResolvedValue('https://example.com');
+    spy.mockResolvedValue('https://example.com');
 
     const response = await request(app).post(`${basePath}`)
-      .query('devMode=true')
-      .send({
-        bodyType: 'text',
-        body: 'body',
-        contexts: contexts,
-        from: 'email@email.com',
-        subject: 'subject'
-      });
+      .query('devMode=true').send(body);
 
     expect(response.statusCode).toBe(201);
     expect(response.body).toBeTruthy();
     expect(response.body).toMatch('https://example.com');
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith(undefined, body, true);
   });
 
   it('should push a message and yield a transasction response', async () => {
-    ChesService.prototype.sendEmailMerge.mockResolvedValue({
+    spy.mockResolvedValue({
       txId: 'asdfasdfadsf',
       messages: [{ msgId: 'qwerqwerqwerw', to: ['email@email.org'] }]
     });
@@ -101,11 +93,13 @@ describe(`POST ${basePath}`, () => {
     expect(response.body.messages).toHaveLength(1);
     expect(response.body.messages[0].to).toHaveLength(1);
     expect(response.body.messages[0].to[0]).toMatch('email@email.org');
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith(undefined, body, false);
   });
 
   it('should fail gracefully when an error occurs', async () => {
     const errorMsg = 'error';
-    ChesService.prototype.sendEmailMerge.mockImplementation(() => {
+    spy.mockImplementation(() => {
       throw new Error(errorMsg);
     });
 
@@ -120,80 +114,72 @@ describe(`POST ${basePath}`, () => {
     expect(response.statusCode).toBe(500);
     expect(response.body).toBeTruthy();
     expect(response.body.details).toBe(errorMsg);
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith(undefined, body, false);
   });
 });
 
 describe(`POST ${basePath}/preview`, () => {
-  it('should yield a validation error for to field', async () => {
-    const response = await request(app).post(`${basePath}/preview`).send({
-      bodyType: 'text',
-      body: 'body',
-      from: 'email@email.com',
-      subject: 'subject',
-      contexts: [
-        {
-          to: undefined,
-          context: { good: 'bad' }
-        }]
-    });
+  const spy = jest.spyOn(mergeComponent, 'mergeTemplate');
+  let body;
 
-    expect(response.statusCode).toBe(422);
-    expect(response.body).toBeTruthy();
-    expect(response.body.detail).toMatch('Validation failed');
-    expect(response.body.errors).toHaveLength(1);
-  });
-
-  it('should yield a validation error for context field', async () => {
-    const response = await request(app).post(`${basePath}/preview`).send({
-      bodyType: 'text',
-      body: 'body',
-      from: 'email@email.com',
-      subject: 'subject',
-      contexts: [
-        {
-          to: ['email@email.com'],
-          context: 'undefined'
-        }]
-    });
-
-    expect(response.statusCode).toBe(422);
-    expect(response.body).toBeTruthy();
-    expect(response.body.detail).toMatch('Validation failed');
-    expect(response.body.errors).toHaveLength(1);
-  });
-
-  it('should yield a nodemailer message object', async () => {
-    const response = await request(app).post(`${basePath}/preview`).send({
+  beforeEach(() => {
+    body = {
       bodyType: 'text',
       body: 'body',
       contexts: contexts,
       from: 'email@email.com',
       subject: 'subject'
-    });
+    };
+  });
+
+  afterEach(() => {
+    spy.mockClear();
+  });
+
+  it('should yield a validation error for to field', async () => {
+    body.contexts = [{ to: undefined, context: { good: 'bad' }}];
+    const response = await request(app).post(`${basePath}/preview`).send(body);
+
+    expect(response.statusCode).toBe(422);
+    expect(response.body).toBeTruthy();
+    expect(response.body.detail).toMatch('Validation failed');
+    expect(response.body.errors).toHaveLength(1);
+    expect(spy).toHaveBeenCalledTimes(0);
+  });
+
+  it('should yield a validation error for context field', async () => {
+    body.contexts = [{ to: ['email@email.com'], context: 'undefined' }];
+    const response = await request(app).post(`${basePath}/preview`).send(body);
+
+    expect(response.statusCode).toBe(422);
+    expect(response.body).toBeTruthy();
+    expect(response.body.detail).toMatch('Validation failed');
+    expect(response.body.errors).toHaveLength(1);
+    expect(spy).toHaveBeenCalledTimes(0);
+  });
+
+  it('should yield a nodemailer message object', async () => {
+    const response = await request(app).post(`${basePath}/preview`).send(body);
 
     expect(response.statusCode).toBe(201);
     expect(response.body).toBeTruthy();
     expect(response.body).toHaveLength(1);
     expect(response.body[0]).toBeTruthy();
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith(body);
   });
 
   it('should respond when sending fails', async () => {
-    const spy = jest.spyOn(mergeComponent, 'mergeTemplate').mockImplementation(() => {
+    spy.mockImplementation(() => {
       throw new Error(errorMessage);
     });
 
-    const response = await request(app).post(`${basePath}/preview`).send({
-      bodyType: 'text',
-      body: 'body',
-      contexts: contexts,
-      from: 'email@email.com',
-      subject: 'subject'
-    });
+    const response = await request(app).post(`${basePath}/preview`).send(body);
 
     expect(response.statusCode).toBe(500);
     expect(response.body).toBeTruthy();
-    expect(spy).toHaveBeenCalled();
-
-    spy.mockRestore();
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith(body);
   });
 });

--- a/app/tests/unit/routes/v1/merge.spec.js
+++ b/app/tests/unit/routes/v1/merge.spec.js
@@ -63,9 +63,7 @@ describe(`POST ${basePath}`, () => {
   });
 
   it('should push a message and yield an Ethereal url', async () => {
-    ChesService.prototype.sendEmailMerge.mockImplementation(() => {
-      return 'https://example.com';
-    });
+    ChesService.prototype.sendEmailMerge.mockResolvedValue('https://example.com');
 
     const response = await request(app).post(`${basePath}`)
       .query('devMode=true')
@@ -83,11 +81,9 @@ describe(`POST ${basePath}`, () => {
   });
 
   it('should push a message and yield a transasction response', async () => {
-    ChesService.prototype.sendEmailMerge.mockImplementation(() => {
-      return {
-        txId: 'asdfasdfadsf',
-        messages: [{ msgId: 'qwerqwerqwerw', to: ['email@email.org'] }]
-      };
+    ChesService.prototype.sendEmailMerge.mockResolvedValue({
+      txId: 'asdfasdfadsf',
+      messages: [{ msgId: 'qwerqwerqwerw', to: ['email@email.org'] }]
     });
 
     const response = await request(app).post(`${basePath}`).send({
@@ -167,7 +163,6 @@ describe(`POST ${basePath}/preview`, () => {
   });
 
   it('should yield a nodemailer message object', async () => {
-
     const response = await request(app).post(`${basePath}/preview`).send({
       bodyType: 'text',
       body: 'body',

--- a/app/tests/unit/routes/v1/status.spec.js
+++ b/app/tests/unit/routes/v1/status.spec.js
@@ -63,7 +63,7 @@ jest.mock('../../../../src/services/chesSvc', () => {
 describe(`POST ${basePath}/:msgId`, () => {
 
   it('should respond with the state of a message', async () => {
-    const id = '11111111-1111-1111-1111-111111111111';
+    const id = '11111111-1111-1111-0111-111111111111';
     const response = await request(app).get(`${basePath}/${id}`);
 
     expect(response.statusCode).toBe(200);

--- a/app/tests/unit/routes/v1/status.spec.js
+++ b/app/tests/unit/routes/v1/status.spec.js
@@ -4,66 +4,145 @@ const request = require('supertest');
 const helper = require('../../../common/helper');
 const router = require('../../../../src/routes/v1/status');
 
+const ChesService = require('../../../../src/services/chesSvc');
+
 // Simple Express Server
 const basePath = '/api/v1/status';
 const app = helper.expressHelper(basePath, router);
 
-const mockNotFound = jest.fn(() => {
-  throw new Problem(404);
-});
+jest.mock('../../../../src/services/chesSvc');
 
-jest.mock('../../../../src/services/chesSvc', () => {
-  return jest.fn(() => {
-    return {
-      getStatus: async (client, msgId) => {
-        if (msgId === '00000000-0000-0000-0000-000000000000') {
-          mockNotFound();
-        }
-        return {
-          createdTimestamp: 1571679721833,
-          delayTS: 0,
-          msgId: msgId,
-          status: 'completed',
-          statusHistory: [
-            {
-              description: null,
-              status: 'completed',
-              timestamp: 1571679722653
-            },
-            {
-              description: null,
-              status: 'delivered',
-              timestamp: 1571679722622
-            },
-            {
-              description: null,
-              status: 'processing',
-              timestamp: 1571679722044
-            },
-            {
-              description: null,
-              status: 'enqueued',
-              timestamp: 1571679721991
-            },
-            {
-              description: null,
-              status: 'accepted',
-              timestamp: 1571679721833
-            }
-          ],
-          tag: 'tag',
-          txId: '00000000-0000-0000-0000-000000000000',
-          updatedTimestamp: 1571679722674
-        };
-      }
-    };
+const getMessageStatus = msgId => {
+  return {
+    createdTimestamp: 1571679721833,
+    delayTS: 0,
+    msgId: msgId,
+    status: 'completed',
+    tag: 'tag',
+    txId: '00000000-0000-0000-0000-000000000000',
+    updatedTimestamp: 1571679722674
+  };
+};
+
+const getMessageStatusHistory = msgId => {
+  const status = getMessageStatus(msgId);
+  status.statusHistory = [
+    {
+      description: null,
+      status: 'completed',
+      timestamp: 1571679722653
+    },
+    {
+      description: null,
+      status: 'delivered',
+      timestamp: 1571679722622
+    },
+    {
+      description: null,
+      status: 'processing',
+      timestamp: 1571679722044
+    },
+    {
+      description: null,
+      status: 'enqueued',
+      timestamp: 1571679721991
+    },
+    {
+      description: null,
+      status: 'accepted',
+      timestamp: 1571679721833
+    }
+  ];
+
+  return status;
+};
+
+describe(`POST ${basePath}`, () => {
+  afterEach(() => {
+    ChesService.prototype.findStatuses.mockClear();
+  });
+
+  it('should respond with an array of messages', async () => {
+    const id = '00000000-0000-0000-0000-000000000000';
+    ChesService.prototype.findStatuses.mockResolvedValue([
+      getMessageStatus(id)
+    ]);
+
+    const response = await request(app).get(`${basePath}`).query({
+      fields: 'createdTimestamp,delayTS,updatedTimestamp',
+      msgId: '00000000-0000-0000-0000-000000000000',
+      status: 'completed',
+      tag: 'tag',
+      txId: '00000000-0000-0000-0000-000000000000'
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.body).toBeTruthy();
+    expect(Array.isArray(response.body)).toBeTruthy();
+    expect(response.body[0].createdTimestamp).toBe(1571679721833);
+    expect(response.body[0].delayTS).toBe(0);
+    expect(response.body[0].msgId).toMatch(id);
+    expect(response.body[0].status).toMatch('completed');
+    expect(response.body[0].tag).toBeTruthy();
+    expect(response.body[0].txId).toBeTruthy();
+    expect(response.body[0].updatedTimestamp).toBe(1571679722674);
+  });
+
+  it('should respond with an empty array if nothing was found', async () => {
+    ChesService.prototype.findStatuses.mockResolvedValue([]);
+
+    const response = await request(app).get(`${basePath}`).query({
+      fields: 'createdTimestamp,delayTS,updatedTimestamp',
+      msgId: '00000000-0000-0000-0000-000000000000',
+      status: 'completed',
+      tag: 'tag',
+      txId: '00000000-0000-0000-0000-000000000000'
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.body).toBeTruthy();
+    expect(Array.isArray(response.body)).toBeTruthy();
+    expect(response.body.length).toBe(0);
+  });
+
+  it('should respond with an internal server error', async () => {
+    const errorMsg = 'error';
+    ChesService.prototype.findStatuses.mockImplementation(() => {
+      throw new Error(errorMsg);
+    });
+
+    const response = await request(app).get(`${basePath}`).query({
+      fields: 'createdTimestamp,delayTS,updatedTimestamp',
+      msgId: '00000000-0000-0000-0000-000000000000',
+      status: 'completed',
+      tag: 'tag',
+      txId: '00000000-0000-0000-0000-000000000000'
+    });
+
+    expect(response.statusCode).toBe(500);
+    expect(response.body.title).toMatch('Internal Server Error');
+    expect(response.body.details).toMatch(errorMsg);
+  });
+
+  it('should respond with a validation error', async () => {
+    const response = await request(app).get(`${basePath}`);
+
+    expect(response.statusCode).toBe(422);
+    expect(response.body).toBeTruthy();
+    expect(response.body.detail).toMatch('Validation failed');
+    expect(response.body.errors).toHaveLength(1);
   });
 });
 
 describe(`POST ${basePath}/:msgId`, () => {
+  afterEach(() => {
+    ChesService.prototype.getStatus.mockClear();
+  });
 
   it('should respond with the state of a message', async () => {
-    const id = '11111111-1111-1111-0111-111111111111';
+    const id = '00000000-0000-0000-0000-000000000000';
+    ChesService.prototype.getStatus.mockResolvedValue(getMessageStatusHistory(id));
+
     const response = await request(app).get(`${basePath}/${id}`);
 
     expect(response.statusCode).toBe(200);
@@ -80,14 +159,23 @@ describe(`POST ${basePath}/:msgId`, () => {
 
   it('should respond with a not found error', async () => {
     const id = '00000000-0000-0000-0000-000000000000';
+    ChesService.prototype.getStatus.mockImplementation(() => {
+      throw new Problem(404);
+    });
+
     const response = await request(app).get(`${basePath}/${id}`);
+
     expect(response.statusCode).toBe(404);
+    expect(response.body.title).toMatch('Not Found');
   });
 
   it('should respond with a validation error', async () => {
     const id = 'badId';
     const response = await request(app).get(`${basePath}/${id}`);
-    expect(response.statusCode).toBe(422);
-  });
 
+    expect(response.statusCode).toBe(422);
+    expect(response.body).toBeTruthy();
+    expect(response.body.detail).toMatch('Validation failed');
+    expect(response.body.errors).toHaveLength(1);
+  });
 });

--- a/app/tests/unit/routes/v1/status.spec.js
+++ b/app/tests/unit/routes/v1/status.spec.js
@@ -128,6 +128,8 @@ describe(`GET ${basePath}`, () => {
     expect(response.body).toBeTruthy();
     expect(response.body.detail).toMatch('Validation failed');
     expect(response.body.errors).toHaveLength(1);
+    expect(response.body.errors[0].value).toMatch('params');
+    expect(response.body.errors[0].message).toMatch('At least one of `msgId`, `status`, `tag` or `txId` must be defined.');
   });
 });
 

--- a/app/tests/unit/routes/v1/status.spec.js
+++ b/app/tests/unit/routes/v1/status.spec.js
@@ -13,10 +13,10 @@ const mockNotFound = jest.fn(() => {
 });
 
 jest.mock('../../../../src/services/chesSvc', () => {
-  return jest.fn().mockImplementation(() => {
+  return jest.fn(() => {
     return {
       getStatus: async (client, msgId) => {
-        if (msgId === 'notfound') {
+        if (msgId === '00000000-0000-0000-0000-000000000000') {
           mockNotFound();
         }
         return {
@@ -79,9 +79,15 @@ describe(`POST ${basePath}/:msgId`, () => {
   });
 
   it('should respond with a not found error', async () => {
-    const id = 'notfound';
+    const id = '00000000-0000-0000-0000-000000000000';
     const response = await request(app).get(`${basePath}/${id}`);
     expect(response.statusCode).toBe(404);
+  });
+
+  it('should respond with a validation error', async () => {
+    const id = 'badId';
+    const response = await request(app).get(`${basePath}/${id}`);
+    expect(response.statusCode).toBe(422);
   });
 
 });

--- a/app/tests/unit/routes/v1/status.spec.js
+++ b/app/tests/unit/routes/v1/status.spec.js
@@ -57,7 +57,7 @@ const getMessageStatusHistory = msgId => {
   return status;
 };
 
-describe(`POST ${basePath}`, () => {
+describe(`GET ${basePath}`, () => {
   afterEach(() => {
     ChesService.prototype.findStatuses.mockClear();
   });
@@ -69,7 +69,6 @@ describe(`POST ${basePath}`, () => {
     ]);
 
     const response = await request(app).get(`${basePath}`).query({
-      fields: 'createdTimestamp,delayTS,updatedTimestamp',
       msgId: '00000000-0000-0000-0000-000000000000',
       status: 'completed',
       tag: 'tag',
@@ -92,7 +91,6 @@ describe(`POST ${basePath}`, () => {
     ChesService.prototype.findStatuses.mockResolvedValue([]);
 
     const response = await request(app).get(`${basePath}`).query({
-      fields: 'createdTimestamp,delayTS,updatedTimestamp',
       msgId: '00000000-0000-0000-0000-000000000000',
       status: 'completed',
       tag: 'tag',
@@ -102,7 +100,7 @@ describe(`POST ${basePath}`, () => {
     expect(response.statusCode).toBe(200);
     expect(response.body).toBeTruthy();
     expect(Array.isArray(response.body)).toBeTruthy();
-    expect(response.body.length).toBe(0);
+    expect(response.body).toHaveLength(0);
   });
 
   it('should respond with an internal server error', async () => {
@@ -112,7 +110,6 @@ describe(`POST ${basePath}`, () => {
     });
 
     const response = await request(app).get(`${basePath}`).query({
-      fields: 'createdTimestamp,delayTS,updatedTimestamp',
       msgId: '00000000-0000-0000-0000-000000000000',
       status: 'completed',
       tag: 'tag',
@@ -134,7 +131,7 @@ describe(`POST ${basePath}`, () => {
   });
 });
 
-describe(`POST ${basePath}/:msgId`, () => {
+describe(`GET ${basePath}/:msgId`, () => {
   afterEach(() => {
     ChesService.prototype.getStatus.mockClear();
   });
@@ -177,5 +174,7 @@ describe(`POST ${basePath}/:msgId`, () => {
     expect(response.body).toBeTruthy();
     expect(response.body.detail).toMatch('Validation failed');
     expect(response.body.errors).toHaveLength(1);
+    expect(response.body.errors[0].value).toBe(id);
+    expect(response.body.errors[0].message).toMatch('Invalid value `msgId`.');
   });
 });


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
This PR implements the /status queryable endpoint as specified in the specification. 
- Adds missing 422 validation support to the /status endpoint family
- Improve unit test code structure for mocking classes
- Refactor transformer into a component
- Refactor validators into model and validator functions
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
[[SHOWCASE-326]](https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-326)

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
Documentation (non-breaking change with enhancements to documentation)
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the OpenAPI 3.0 `v*.api-spec.yaml` documentation (if appropriate)
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
