### PR TITLE
Bugfix non-default columns were not being returned for status query

### DIFF
--- a/app/src/services/dataSvc.js
+++ b/app/src/services/dataSvc.js
@@ -170,6 +170,15 @@ class DataService {
    *  @returns {object[]} Array of Message objects with a subset of properties
    */
   async findMessagesByQuery(client, messageId, status, tag, transactionId, fields = []) {
+    const validColumns = [
+      'createdAt',
+      'delayTimestamp',
+      'messageId',
+      'status',
+      'tag',
+      'transactionId',
+      'updatedAt'
+    ];
     const parameters = utils.dropUndefinedObject({
       messageId: messageId,
       status: status,
@@ -177,10 +186,9 @@ class DataService {
       transactionId: transactionId
     });
 
-    const columns = ['messageId', 'status', 'tag', 'transactionId']
-      .concat(fields.filter(field => {
-        return ['createdAt', 'delayTimestamp', 'updatedAt'].includes(field);
-      }));
+    const columns = [... new Set(validColumns.concat(fields.filter(field => {
+      return validColumns.includes(field);
+    })))];
 
     const trxnQuery = Trxn.query()
       .select('transactionId')


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
This bugfix ensures that the /status endpoint actually returns values for createdTS, delayTS and updatedTS instead of null.
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the OpenAPI 3.0 `v*.api-spec.yaml` documentation (if appropriate)
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
