### PR TITLE
Add /cancel query support to API

### DIFF
--- a/app/bin/www
+++ b/app/bin/www
@@ -60,16 +60,16 @@ function onError(error) {
 
   // handle specific listen errors with friendly messages
   switch (error.code) {
-  case 'EACCES':
-    log.error(bind + ' requires elevated privileges');
-    process.exit(1);
-    break;
-  case 'EADDRINUSE':
-    log.error(bind + ' is already in use');
-    process.exit(1);
-    break;
-  default:
-    throw error;
+    case 'EACCES':
+      log.error(bind + ' requires elevated privileges');
+      process.exit(1);
+      break;
+    case 'EADDRINUSE':
+      log.error(bind + ' is already in use');
+      process.exit(1);
+      break;
+    default:
+      throw error;
   }
 }
 

--- a/app/src/components/validators.js
+++ b/app/src/components/validators.js
@@ -282,6 +282,21 @@ const validators = {
     return errors;
   },
 
+  cancelQuery: query => {
+    const errors = [];
+
+    if (!query || !Object.keys(query).some(param => validator.isIn(param, ['msgId', 'status', 'tag', 'txId']))) {
+      errors.push({
+        value: 'params',
+        message: 'At least one of `msgId`, `status`, `tag` or `txId` must be defined.'
+      });
+    }
+
+    validators.searchQueryFields(query).forEach(error => errors.push(error));
+
+    return errors;
+  },
+
   contexts: obj => {
     const errors = [];
     if (obj.contexts) {
@@ -412,17 +427,6 @@ const validators = {
     }
 
     validators.searchQueryFields(query).forEach(error => errors.push(error));
-
-    if (query && query.fields) {
-      query.fields.split(',').forEach(field => {
-        if (!validator.isIn(field, ['createdTimestamp', 'delayTS', 'updatedTimestamp'])) {
-          errors.push({
-            value: 'fields',
-            message: `Value \`${field}\` is not one of \`createdTimestamp\`, \`delayTS\`, or \`updatedTimestamp\`.`
-          });
-        }
-      });
-    }
 
     return errors;
   },

--- a/app/src/components/validators.js
+++ b/app/src/components/validators.js
@@ -4,6 +4,8 @@ const log = require('npmlog');
 const tmp = require('tmp');
 const validator = require('validator');
 
+const { statusState } = require('./state');
+
 const DEFAULT_ATTACHMENT_SIZE = bytes.parse('5mb');
 
 const asyncForEach = async (array, callback) => {
@@ -200,10 +202,9 @@ const models = {
     },
 
     /** @function status */
-    // TODO: Change this to enforce an enumeration of valid states
     status: value => {
       if (value) {
-        return validatorUtils.isString(value) && !validator.isEmpty(value, { ignore_whitespace: true });
+        return validatorUtils.isString(value) && !validator.isEmpty(value, { ignore_whitespace: true }) && Object.values(statusState).includes(value);
       }
       return true;
     },

--- a/app/src/docs/v1.api-spec.yaml
+++ b/app/src/docs/v1.api-spec.yaml
@@ -276,7 +276,7 @@ paths:
                 URL location to affected resource. Use the same query and path
                 parameters as this request to find the affected resource.
               example: >-
-                /api/v1/status?msgId=00000000-0000-0000-0000-000000000000&status=completed&tag=example&txId=00000000-0000-0000-0000-000000000000
+                /api/v1/status?msgId=00000000-0000-0000-0000-000000000000&status=pending&tag=example&txId=00000000-0000-0000-0000-000000000000
               schema:
                 type: string
                 format: uri
@@ -366,7 +366,7 @@ components:
           - completed
           - failed
           - pending
-      example: completed
+      example: pending
     QueryTag:
       in: query
       name: tag

--- a/app/src/docs/v1.api-spec.yaml
+++ b/app/src/docs/v1.api-spec.yaml
@@ -276,7 +276,7 @@ paths:
                 URL location to affected resource. Use the same query and path
                 parameters as this request to find the affected resource.
               example: >-
-                /status?msgId=00000000-0000-0000-0000-000000000000&status=completed&tag=example&txId=00000000-0000-0000-0000-000000000000
+                /api/v1/status?msgId=00000000-0000-0000-0000-000000000000&status=completed&tag=example&txId=00000000-0000-0000-0000-000000000000
               schema:
                 type: string
                 format: uri
@@ -315,7 +315,7 @@ paths:
               description: >-
                 URL location to affected resource. Use the same query and path
                 parameters as this request to find the affected resource.
-              example: /status/00000000-0000-0000-0000-000000000000
+              example: /api/v1/status/00000000-0000-0000-0000-000000000000
               schema:
                 type: string
                 format: uri

--- a/app/src/middleware/validation.js
+++ b/app/src/middleware/validation.js
@@ -13,36 +13,37 @@ const handleValidationErrors = (res, next, errors) => {
   next();
 };
 
-const validateCancelMsg = (req, res, next) => {
-  const errors = validators.cancelMsg(req.params);
-  handleValidationErrors(res, next, errors);
+const validation = {
+  validateCancelMsg: (req, res, next) => {
+    const errors = validators.cancelMsg(req.params);
+    handleValidationErrors(res, next, errors);
+  },
+
+  validateCancelQuery: (req, res, next) => {
+    const errors = validators.cancelQuery(req.query);
+    handleValidationErrors(res, next, errors);
+  },
+
+  validateEmail: async (req, res, next) => {
+    const errors = await validators.email(req.body, config.get('server.attachmentLimit'));
+    handleValidationErrors(res, next, errors);
+  },
+
+  validateMerge: async (req, res, next) => {
+    const errors = await validators.merge(req.body, config.get('server.attachmentLimit'));
+    handleValidationErrors(res, next, errors);
+
+  },
+
+  validateStatusFetch: (req, res, next) => {
+    const errors = validators.statusFetch(req.params);
+    handleValidationErrors(res, next, errors);
+  },
+
+  validateStatusQuery: (req, res, next) => {
+    const errors = validators.statusQuery(req.query);
+    handleValidationErrors(res, next, errors);
+  }
 };
 
-const validateEmail = async (req, res, next) => {
-  const errors = await validators.email(req.body, config.get('server.attachmentLimit'));
-  handleValidationErrors(res, next, errors);
-};
-
-const validateMerge = async (req, res, next) => {
-  const errors = await validators.merge(req.body, config.get('server.attachmentLimit'));
-  handleValidationErrors(res, next, errors);
-
-};
-
-const validateStatusFetch = (req, res, next) => {
-  const errors = validators.statusFetch(req.params);
-  handleValidationErrors(res, next, errors);
-};
-
-const validateStatusQuery = (req, res, next) => {
-  const errors = validators.statusQuery(req.query);
-  handleValidationErrors(res, next, errors);
-};
-
-module.exports = {
-  validateCancelMsg,
-  validateEmail,
-  validateMerge,
-  validateStatusFetch,
-  validateStatusQuery
-};
+module.exports = validation;

--- a/app/src/routes/v1/cancel.js
+++ b/app/src/routes/v1/cancel.js
@@ -1,11 +1,11 @@
 const cancelRouter = require('express').Router();
-const { validateCancelMsg } = require('../../middleware/validation');
+const { validateCancelQuery, validateCancelMsg } = require('../../middleware/validation');
 const ChesService = require('../../services/chesSvc');
 
 const chesService = new ChesService();
 
 /** Cancel multiple delayed messages endpoint */
-cancelRouter.delete('/', async (req, res, next) => {
+cancelRouter.delete('/', validateCancelQuery, async (req, res, next) => {
   try {
     await chesService.findCancelMessages(req.authorizedParty, req.query.msgId,
       req.query.status, req.query.tag, req.query.txId);

--- a/app/src/routes/v1/cancel.js
+++ b/app/src/routes/v1/cancel.js
@@ -9,7 +9,9 @@ cancelRouter.delete('/:msgId', validateCancelMsg, async (req, res, next) => {
   try {
     await chesService.cancelMessage(req.authorizedParty, req.params.msgId);
 
-    res.status(202).end();
+    res.status(202)
+      .header('Content-Location', req.originalUrl.replace('cancel', 'status'))
+      .end();
   } catch (err) {
     next(err);
   }

--- a/app/src/routes/v1/cancel.js
+++ b/app/src/routes/v1/cancel.js
@@ -4,6 +4,20 @@ const ChesService = require('../../services/chesSvc');
 
 const chesService = new ChesService();
 
+/** Cancel multiple delayed messages endpoint */
+cancelRouter.delete('/', async (req, res, next) => {
+  try {
+    await chesService.findCancelMessages(req.authorizedParty, req.query.msgId,
+      req.query.status, req.query.tag, req.query.txId);
+
+    res.status(202)
+      .header('Content-Location', req.originalUrl.replace('cancel', 'status'))
+      .end();
+  } catch (err) {
+    next(err);
+  }
+});
+
 /** Cancel a single delayed message endpoint */
 cancelRouter.delete('/:msgId', validateCancelMsg, async (req, res, next) => {
   try {

--- a/app/src/services/chesSvc.js
+++ b/app/src/services/chesSvc.js
@@ -338,7 +338,7 @@ class ChesService {
         return transformer.toTransactionResponse(trxn);
       }
     } catch (e) {
-      log.error(`Send Email Merge error. ${e.message}`);
+      log.error('sendEmailMerge', `Send Email Merge error. ${e.message}`);
       log.error(utils.prettyStringify(e));
       throw new Problem(500, { detail: `Error sending email merge. ${e.message}` });
     }

--- a/app/src/services/chesSvc.js
+++ b/app/src/services/chesSvc.js
@@ -134,6 +134,31 @@ class ChesService {
   }
 
   /**
+   * @function findCancelMessages
+   * @description Finds and attempts to cancel the set of messages matching the search criteria
+   *
+   * @param {string} client - the authorized party / client
+   * @param {string} messageId - the id of the desired message
+   * @param {string} status - the desired status of the messages
+   * @param {string} tag - the desired tag of the messages
+   * @param {string} transactionId - the id of the desired transaction
+   * @throws Problem if an unexpected error occurs
+   */
+  // eslint-disable-next-line no-unused-vars
+  async findCancelMessages(client, messageId, status, tag, transactionId) {
+    try {
+      // await this.dataService.findMessagesByQuery(client, messageId, status, tag, transactionId);
+    } catch (e) {
+      if (e instanceof NotFoundError) {
+        log.verbose('findCancelMessages', 'No messages found');
+      } else {
+        log.error('findCancelMessages', e.message);
+        throw new Problem(500, { detail: `Unexpected Error: ${e.message}` });
+      }
+    }
+  }
+
+  /**
    * @function findStatuses
    * @description Finds the set of message statuses that matches the search criteria
    *

--- a/app/src/services/dataSvc.js
+++ b/app/src/services/dataSvc.js
@@ -131,7 +131,7 @@ class DataService {
       stackpole.createTransaction(client, result);
       return result;
     } catch (err) {
-      log.error(`Error creating transaction record: ${err.message}. Rolling back...`);
+      log.error('createTransaction', `Error creating transaction record: ${err.message}. Rolling back...`);
       log.error(err);
       if (trx) await trx.rollback();
       throw err;
@@ -164,7 +164,7 @@ class DataService {
 
       return await this.readMessage(client, messageId);
     } catch (err) {
-      log.error(`Error updating message (email) record: ${err.message}. Rolling back...`);
+      log.error('deleteMessageEmail', `Error updating message (email) record: ${err.message}. Rolling back...`);
       log.error(err);
       if (trx) await trx.rollback();
       throw err;
@@ -288,7 +288,7 @@ class DataService {
 
       return await this.readMessage(client, messageId);
     } catch (err) {
-      log.error(`Error updating message send result record: ${err.message}. Rolling back...`);
+      log.error('updateMessageSendResult', `Error updating message send result record: ${err.message}. Rolling back...`);
       log.error(err);
       if (trx) await trx.rollback();
       throw err;
@@ -341,7 +341,7 @@ class DataService {
       stackpole.updateStatus(client, result);
       return result;
     } catch (err) {
-      log.error(`Error updating message statuses record: ${err.message}. Rolling back...`);
+      log.error('updateStatus', `Error updating message statuses record: ${err.message}. Rolling back...`);
       log.error(err);
       if (trx) await trx.rollback();
       throw err;

--- a/app/src/services/queueSvc.js
+++ b/app/src/services/queueSvc.js
@@ -209,12 +209,12 @@ class QueueService {
 
     if (job && job.data && job.data.client && job.data.messageId) {
       // Job found with proper structure
-      if (job.data.client !== client) {
-        throw new ClientMismatchError();
-      } else if (job.data.messageId !== jobId) {
-        throw new DataIntegrityError();
+      if (job.data.messageId !== jobId) {
+        throw new DataIntegrityError(`Message ${jobId} data is inconsistent or corrupted.`);
+      } else if (job.data.client !== client) {
+        throw new ClientMismatchError(`Message ${jobId} is not owned by client ${job.data.client}.`);
       } else if (await job.getState() !== 'delayed') {
-        throw new UncancellableError();
+        throw new UncancellableError(`Message ${jobId} is not cancellable.`);
       } else {
         // Immediately remove from queue
         await job.remove();

--- a/app/src/services/queueSvc.js
+++ b/app/src/services/queueSvc.js
@@ -187,7 +187,7 @@ class QueueService {
         const sendResult = { smtpMsgId: smtpResult.messageId, response: smtpResult.response };
         await this.dataService.updateMessageSendResult(job.data.client, job.data.messageId, sendResult);
       } catch (e) {
-        log.error(`Error sending message from queue: client = ${job.data.client}, messageId = ${job.data.messageId}. ${e.message}`);
+        log.error('sendMessage', `Error sending message from queue: client = ${job.data.client}, messageId = ${job.data.messageId}. ${e.message}`);
         log.error(utils.prettyStringify(e));
       }
     }

--- a/app/src/services/statisticSvc.js
+++ b/app/src/services/statisticSvc.js
@@ -61,7 +61,7 @@ class StatisticsService {
       await trx.commit();
 
     } catch (err) {
-      log.error(`Error creating statistic records: ${err.message}. Rolling back...`);
+      log.error('write', `Error creating statistic records: ${err.message}. Rolling back...`);
       log.error(err);
       if (trx) await trx.rollback();
     }

--- a/app/tests/integration/chesSvc.spec.js
+++ b/app/tests/integration/chesSvc.spec.js
@@ -264,6 +264,61 @@ describe('chesService', () => {
 
   });
 
+  describe('findCancelMessages', () => {
+    // const spy = jest.spyOn(DataService.prototype, 'findMessagesByQuery');
+
+    // afterEach(() => {
+    //   spy.mockClear();
+    // });
+
+    it.skip('should throw an error with no parameters provided', async () => {
+      const fn = () => chesService.findCancelMessages();
+
+      await expect(fn()).rejects.toThrow();
+
+      // expect(spy).toHaveBeenCalledTimes(1);
+      // expect(spy).toHaveBeenCalledWith(undefined, undefined, undefined, undefined, undefined);
+    });
+
+    it.skip('should throw an error with no search parameters', async () => {
+      const CLIENT = `ches-svc-findCancelMessages-${new Date().toISOString()}`;
+      const fn = () => chesService.findCancelMessages(CLIENT);
+
+      await expect(fn()).resolves.toThrow();
+
+      // expect(Array.isArray(result)).toBeTruthy();
+      // expect(result).toHaveLength(0);
+      // expect(spy).toHaveBeenCalledTimes(1);
+      // expect(spy).toHaveBeenCalledWith(CLIENT, undefined, undefined, undefined, undefined);
+
+      await deleteTransactionsByClient(CLIENT);
+    });
+
+    it('should return with all nonexistent search parameters', async () => {
+      const CLIENT = `ches-svc-findCancelMessages-${new Date().toISOString()}`;
+      const msgId = uuidv4();
+      const txId = uuidv4();
+      const fn = () => chesService.findCancelMessages(CLIENT, msgId, 'status', 'tag', txId);
+
+      await expect(fn()).resolves.not.toThrow();
+      // expect(spy).toHaveBeenCalledTimes(1);
+      // expect(spy).toHaveBeenCalledWith(CLIENT, msgId, 'status', 'tag', txId);
+
+      await deleteTransactionsByClient(CLIENT);
+    });
+
+    it('should return an array of message statuses', async () => {
+      const trxn = await chesService.sendEmail(CLIENT, emails[0], false);
+
+      const fn = () => chesService.findCancelMessages(CLIENT, undefined, undefined, undefined, trxn.txId);
+
+      await expect(fn()).resolves.not.toThrow();
+      // expect(spy).toHaveBeenCalledTimes(1);
+      // expect(spy).toHaveBeenCalledWith(CLIENT, undefined, undefined, undefined, trxn.txId);
+    });
+
+  });
+
   describe('findStatuses', () => {
     const spy = jest.spyOn(DataService.prototype, 'findMessagesByQuery');
 

--- a/app/tests/integration/chesSvc.spec.js
+++ b/app/tests/integration/chesSvc.spec.js
@@ -18,7 +18,9 @@ const Bull = require('bull');
 const config = require('config');
 const helper = require('../common/helper');
 const Knex = require('knex');
+const { NotFoundError } = require('objection');
 const uuidv4 = require('uuid/v4');
+const Problem = require('api-problem');
 
 const { statusState, queueState } = require('../../src/components/state');
 const stackpole = require('../../src/components/stackpole');
@@ -31,7 +33,12 @@ const QueueConnection = require('../../src/services/queueConn');
 const ChesService = require('../../src/services/chesSvc');
 const DataService = require('../../src/services/dataSvc');
 const EmailService = require('../../src/services/emailSvc');
-const { ClientMismatchError, DataIntegrityError, QueueService } = require('../../src/services/queueSvc');
+const {
+  ClientMismatchError,
+  DataIntegrityError,
+  UncancellableError,
+  QueueService
+} = require('../../src/services/queueSvc');
 
 const { deleteTransactionsByClient } = require('./dataUtils');
 
@@ -265,15 +272,18 @@ describe('chesService', () => {
   });
 
   describe('findCancelMessages', () => {
+    const CLIENT = `ches-svc-findCancelMessages-${new Date().toISOString()}`;
+
     const findSpy = jest.spyOn(DataService.prototype, 'findMessagesByQuery');
     const removeSpy = jest.spyOn(QueueService.prototype, 'removeJob');
     const fn = (...args) => {
       return chesService.findCancelMessages(...args);
     };
 
-    afterEach(() => {
+    afterEach(async () => {
       findSpy.mockClear();
       removeSpy.mockClear();
+      await deleteTransactionsByClient(CLIENT);
     });
 
     it('should throw an error with no parameters provided', async () => {
@@ -284,20 +294,15 @@ describe('chesService', () => {
     });
 
     it('should return nothing with no search parameters', async () => {
-      const CLIENT = `ches-svc-findCancelMessages-${new Date().toISOString()}`;
-
       const result = await fn(CLIENT);
 
       expect(result).toBeFalsy();
       expect(findSpy).toHaveBeenCalledTimes(1);
       expect(findSpy).toHaveBeenCalledWith(CLIENT, undefined, undefined, undefined, undefined);
       expect(removeSpy).toHaveBeenCalledTimes(0);
-
-      await deleteTransactionsByClient(CLIENT);
     });
 
     it('should return nothing with all nonexistent search parameters', async () => {
-      const CLIENT = `ches-svc-findCancelMessages-${new Date().toISOString()}`;
       const msgId = uuidv4();
       const txId = uuidv4();
       const status = statusState.COMPLETED;
@@ -309,8 +314,6 @@ describe('chesService', () => {
       expect(findSpy).toHaveBeenCalledTimes(1);
       expect(findSpy).toHaveBeenCalledWith(CLIENT, msgId, status, tag, txId);
       expect(removeSpy).toHaveBeenCalledTimes(0);
-
-      await deleteTransactionsByClient(CLIENT);
     });
 
     it('should return nothing with one message ', async () => {
@@ -325,18 +328,100 @@ describe('chesService', () => {
       expect(removeSpy).toHaveBeenCalledWith(CLIENT, trxn.messages[0].msgId);
     });
 
+    it('should return nothing when there is a ClientMismatchError', async () => {
+      const trxn = await chesService.sendEmail(CLIENT, emails[0], false);
+      removeSpy.mockImplementation(() => {
+        throw new ClientMismatchError('test');
+      });
+
+      const result = await fn(CLIENT, trxn.messages[0].msgId, undefined, undefined, undefined);
+
+      expect(result).toBeFalsy();
+      expect(findSpy).toHaveBeenCalledTimes(1);
+      expect(findSpy).toHaveBeenCalledWith(CLIENT, trxn.messages[0].msgId, undefined, undefined, undefined);
+      expect(removeSpy).toHaveBeenCalledTimes(1);
+      expect(removeSpy).toHaveBeenCalledWith(CLIENT, trxn.messages[0].msgId);
+    });
+
+    it('should return nothing when there is a NotFoundError', async () => {
+      const trxn = await chesService.sendEmail(CLIENT, emails[0], false);
+      removeSpy.mockImplementation(() => {
+        throw new NotFoundError('test');
+      });
+
+      const result = await fn(CLIENT, trxn.messages[0].msgId, undefined, undefined, undefined);
+
+      expect(result).toBeFalsy();
+      expect(findSpy).toHaveBeenCalledTimes(1);
+      expect(findSpy).toHaveBeenCalledWith(CLIENT, trxn.messages[0].msgId, undefined, undefined, undefined);
+      expect(removeSpy).toHaveBeenCalledTimes(1);
+      expect(removeSpy).toHaveBeenCalledWith(CLIENT, trxn.messages[0].msgId);
+    });
+
+    it('should return nothing when there is a UncancellableError', async () => {
+      const trxn = await chesService.sendEmail(CLIENT, emails[0], false);
+      removeSpy.mockImplementation(() => {
+        throw new UncancellableError('test');
+      });
+
+      const result = await fn(CLIENT, trxn.messages[0].msgId, undefined, undefined, undefined);
+
+      expect(result).toBeFalsy();
+      expect(findSpy).toHaveBeenCalledTimes(1);
+      expect(findSpy).toHaveBeenCalledWith(CLIENT, trxn.messages[0].msgId, undefined, undefined, undefined);
+      expect(removeSpy).toHaveBeenCalledTimes(1);
+      expect(removeSpy).toHaveBeenCalledWith(CLIENT, trxn.messages[0].msgId);
+    });
+
+    it('should throw an error when there is a DataIntegrityError', async () => {
+      const trxn = await chesService.sendEmail(CLIENT, emails[0], false);
+      removeSpy.mockImplementation(() => {
+        throw new DataIntegrityError('test');
+      });
+
+      await expect(fn(CLIENT, trxn.messages[0].msgId, undefined, undefined, undefined)).rejects.toThrow(new Problem(500, {
+        detail: 'Some message(s) are inconsistent or corrupted.',
+        messages: [
+          trxn.messages[0].msgId
+        ]
+      }));
+
+      expect(findSpy).toHaveBeenCalledTimes(1);
+      expect(findSpy).toHaveBeenCalledWith(CLIENT, trxn.messages[0].msgId, undefined, undefined, undefined);
+      expect(removeSpy).toHaveBeenCalledTimes(1);
+      expect(removeSpy).toHaveBeenCalledWith(CLIENT, trxn.messages[0].msgId);
+    });
+
+    it('should throw an error when there is a generic error', async () => {
+      const errMsg = 'test';
+      const trxn = await chesService.sendEmail(CLIENT, emails[0], false);
+      removeSpy.mockImplementation(() => {
+        throw new Error(errMsg);
+      });
+
+      await expect(fn(CLIENT, trxn.messages[0].msgId, undefined, undefined, undefined)).rejects.toThrow(new Problem(500, { detail: `Unexpected Error: ${errMsg}` }));
+
+      expect(findSpy).toHaveBeenCalledTimes(1);
+      expect(findSpy).toHaveBeenCalledWith(CLIENT, trxn.messages[0].msgId, undefined, undefined, undefined);
+      expect(removeSpy).toHaveBeenCalledTimes(1);
+      expect(removeSpy).toHaveBeenCalledWith(CLIENT, trxn.messages[0].msgId);
+    });
+
   });
 
   describe('findStatuses', () => {
+    const CLIENT = `ches-svc-findStatuses-${new Date().toISOString()}`;
     const spy = jest.spyOn(DataService.prototype, 'findMessagesByQuery');
+    const fn = (...args) => {
+      return chesService.findStatuses(...args);
+    };
 
-    afterEach(() => {
+    afterEach(async () => {
       spy.mockClear();
+      await deleteTransactionsByClient(CLIENT);
     });
 
     it('should throw an error if no parameters were provided', async () => {
-      const fn = () => chesService.findStatuses();
-
       await expect(fn()).rejects.toThrow();
 
       expect(spy).toHaveBeenCalledTimes(1);
@@ -344,8 +429,8 @@ describe('chesService', () => {
     });
 
     it('should return an empty array with no search parameters', async () => {
-      const CLIENT = `ches-svc-findStatuses-${new Date().toISOString()}`;
-      const result = await chesService.findStatuses(CLIENT);
+
+      const result = await fn(CLIENT);
 
       expect(Array.isArray(result)).toBeTruthy();
       expect(result).toHaveLength(0);
@@ -356,23 +441,20 @@ describe('chesService', () => {
     });
 
     it('should return an empty array with all nonexistent search parameters', async () => {
-      const CLIENT = `ches-svc-findStatuses-${new Date().toISOString()}`;
       const msgId = uuidv4();
       const txId = uuidv4();
-      const result = await chesService.findStatuses(CLIENT, msgId, 'status', 'tag', txId);
+      const result = await fn(CLIENT, msgId, 'status', 'tag', txId);
 
       expect(Array.isArray(result)).toBeTruthy();
       expect(result).toHaveLength(0);
       expect(spy).toHaveBeenCalledTimes(1);
       expect(spy).toHaveBeenCalledWith(CLIENT, msgId, 'status', 'tag', txId);
-
-      await deleteTransactionsByClient(CLIENT);
     });
 
     it('should return an array of message statuses', async () => {
       const trxn = await chesService.sendEmail(CLIENT, emails[0], false);
 
-      const result = await chesService.findStatuses(CLIENT, undefined, undefined, undefined, trxn.txId);
+      const result = await fn(CLIENT, undefined, undefined, undefined, trxn.txId);
 
       expect(Array.isArray(result)).toBeTruthy();
       expect(result).toHaveLength(1);

--- a/app/tests/unit/components/validators.spec.js
+++ b/app/tests/unit/components/validators.spec.js
@@ -1344,6 +1344,58 @@ describe('validators.cancelMsg', () => {
   });
 });
 
+describe('validators.cancelQuery', () => {
+  let query;
+
+  beforeEach(() => {
+    query = {
+      msgId: '00000000-0000-0000-0000-000000000000',
+      status: 'completed',
+      tag: 'tag',
+      txId: '00000000-0000-0000-0000-000000000000'
+    };
+  });
+
+  it('should return an empty error array when all valid', () => {
+    const result = validators.cancelQuery(query);
+
+    expect(result).toBeTruthy();
+    expect(Array.isArray(result)).toBeTruthy();
+    expect(result.length).toEqual(0);
+  });
+
+  it('should return an empty error array with some missing parameters', () => {
+    delete query.status;
+    delete query.txId;
+
+    const result = validators.cancelQuery(query);
+
+    expect(result).toBeTruthy();
+    expect(Array.isArray(result)).toBeTruthy();
+    expect(result.length).toEqual(0);
+  });
+
+  it('should return an error with some validation errors', () => {
+    query.txId = 'garbage';
+
+    const result = validators.cancelQuery(query);
+
+    expect(result).toBeTruthy();
+    expect(Array.isArray(result)).toBeTruthy();
+    expect(result.length).toEqual(1);
+  });
+
+  it('should return an error when all parameters are missing', () => {
+    const result = validators.cancelQuery({});
+
+    expect(result).toBeTruthy();
+    expect(Array.isArray(result)).toBeTruthy();
+    expect(result.length).toEqual(1);
+    expect(result[0].message).toMatch(/At least one of/);
+    expect(result[0].value).toMatch('params');
+  });
+});
+
 describe('validators.email', () => {
 
   const goodEmail = {
@@ -1870,7 +1922,6 @@ describe('validators.statusQuery', () => {
 
   beforeEach(() => {
     query = {
-      fields: 'createdTimestamp,delayTS,updatedTimestamp',
       msgId: '00000000-0000-0000-0000-000000000000',
       status: 'completed',
       tag: 'tag',
@@ -1915,18 +1966,6 @@ describe('validators.statusQuery', () => {
     expect(result.length).toEqual(1);
     expect(result[0].message).toMatch(/At least one of/);
     expect(result[0].value).toMatch('params');
-  });
-
-  it('should return an error with invalid field content', () => {
-    query.fields = 'garbage,delayTS';
-
-    const result = validators.statusQuery(query);
-
-    expect(result).toBeTruthy();
-    expect(Array.isArray(result)).toBeTruthy();
-    expect(result.length).toEqual(1);
-    expect(result[0].message).toMatch(/Value.*is not one of/);
-    expect(result[0].value).toMatch('fields');
   });
 });
 

--- a/app/tests/unit/components/validators.spec.js
+++ b/app/tests/unit/components/validators.spec.js
@@ -1070,12 +1070,28 @@ describe('models.queryParams.msgId', () => {
 describe('models.queryParams.status', () => {
   const fn = models.queryParams.status;
 
-  it('should return true for a string', () => {
-    expect(fn('this is a status')).toBeTruthy();
+  it('should return true for a valid string', () => {
+    expect(fn('accepted')).toBeTruthy();
+    expect(fn('cancelled')).toBeTruthy();
+    expect(fn('completed')).toBeTruthy();
+    expect(fn('failed')).toBeTruthy();
+    expect(fn('pending')).toBeTruthy();
   });
 
-  it('should return true for a string object', () => {
-    expect(fn(String('this is a status'))).toBeTruthy();
+  it('should return true for a valid string object', () => {
+    expect(fn(String('accepted'))).toBeTruthy();
+    expect(fn(String('cancelled'))).toBeTruthy();
+    expect(fn(String('completed'))).toBeTruthy();
+    expect(fn(String('failed'))).toBeTruthy();
+    expect(fn(String('pending'))).toBeTruthy();
+  });
+
+  it('should return false for an invalid string', () => {
+    expect(fn('invalid')).toBeFalsy();
+  });
+
+  it('should return true for an invalid string object', () => {
+    expect(fn(String('invalid'))).toBeFalsy();
   });
 
   it('should return true for undefined', () => {

--- a/app/tests/unit/routes/v1/cancel.spec.js
+++ b/app/tests/unit/routes/v1/cancel.spec.js
@@ -12,6 +12,95 @@ const app = helper.expressHelper(basePath, router);
 
 jest.mock('../../../../src/services/chesSvc');
 
+describe(`DELETE ${basePath}`, () => {
+  const spy = ChesService.prototype.findCancelMessages;
+
+  afterEach(() => {
+    ChesService.prototype.findCancelMessages.mockClear();
+  });
+
+  it('should respond with an acknowledgement when a message is found', async () => {
+    spy.mockResolvedValue(undefined);
+    const query = {
+      msgId: '00000000-0000-0000-0000-000000000000'
+    };
+
+    const response = await request(app).delete(`${basePath}`).query(query);
+    expect(response.statusCode).toBe(202);
+    expect(response.header).toHaveProperty('content-location');
+    expect(response.header['content-location']).toMatch(response.req.path.replace('cancel', 'status'));
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith(undefined, query.msgId, undefined, undefined, undefined);
+  });
+
+  it('should respond with an acknowledgement when multiple messages are found', async () => {
+    spy.mockResolvedValue(undefined);
+    const query = {
+      msgId: '00000000-0000-0000-0000-000000000000',
+      status: 'pending',
+      tag: 'tag',
+      txId: '00000000-0000-0000-0000-000000000000'
+    };
+
+    const response = await request(app).delete(`${basePath}`).query(query);
+    expect(response.statusCode).toBe(202);
+    expect(response.header).toHaveProperty('content-location');
+    expect(response.header['content-location']).toMatch(response.req.path.replace('cancel', 'status'));
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith(undefined, query.msgId, query.status, query.tag, query.txId);
+  });
+
+  it('should respond with an acknowledgement when nothing is found', async () => {
+    spy.mockResolvedValue(undefined);
+    const query = {
+      msgId: '00000000-0000-0000-0000-000000000000',
+      status: 'accepted',
+      tag: 'tag',
+      txId: '00000000-0000-0000-0000-000000000000'
+    };
+
+    const response = await request(app).delete(`${basePath}`).query(query);
+
+    expect(response.statusCode).toBe(202);
+    expect(response.header).toHaveProperty('content-location');
+    expect(response.header['content-location']).toMatch(response.req.path.replace('cancel', 'status'));
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith(undefined, query.msgId, query.status, query.tag, query.txId);
+  });
+
+  it('should respond with an internal server error', async () => {
+    const errorMsg = 'error';
+    const query = {
+      msgId: '00000000-0000-0000-0000-000000000000',
+      status: 'pending',
+      tag: 'tag',
+      txId: '00000000-0000-0000-0000-000000000000'
+    };
+    spy.mockImplementation(() => {
+      throw new Error(errorMsg);
+    });
+
+    const response = await request(app).delete(`${basePath}`).query(query);
+
+    expect(response.statusCode).toBe(500);
+    expect(response.body.title).toMatch('Internal Server Error');
+    expect(response.body.details).toMatch(errorMsg);
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith(undefined, query.msgId, query.status, query.tag, query.txId);
+  });
+
+  it.skip('should respond with a validation error', async () => {
+    const response = await request(app).delete(`${basePath}`);
+
+    expect(response.statusCode).toBe(422);
+    expect(response.body).toBeTruthy();
+    expect(response.body.detail).toMatch('Validation failed');
+    expect(response.body.errors).toHaveLength(1);
+    expect(response.body.errors[0].value).toMatch('params');
+    expect(response.body.errors[0].message).toMatch('At least one of `msgId`, `status`, `tag` or `txId` must be defined.');
+  });
+});
+
 describe(`DELETE ${basePath}/:msgId`, () => {
   const spy = ChesService.prototype.cancelMessage;
 

--- a/app/tests/unit/routes/v1/cancel.spec.js
+++ b/app/tests/unit/routes/v1/cancel.spec.js
@@ -24,8 +24,9 @@ describe(`DELETE ${basePath}/:msgId`, () => {
     const id = '00000000-0000-0000-0000-000000000000';
 
     const response = await request(app).delete(`${basePath}/${id}`);
-
     expect(response.statusCode).toBe(202);
+    expect(response.header).toHaveProperty('content-location');
+    expect(response.header['content-location']).toMatch(response.req.path.replace('cancel', 'status'));
     expect(spy).toHaveBeenCalledTimes(1);
     expect(spy).toHaveBeenCalledWith(undefined, id);
   });

--- a/app/tests/unit/routes/v1/cancel.spec.js
+++ b/app/tests/unit/routes/v1/cancel.spec.js
@@ -14,16 +14,26 @@ jest.mock('../../../../src/services/chesSvc');
 
 describe(`DELETE ${basePath}`, () => {
   const spy = ChesService.prototype.findCancelMessages;
+  let query;
+
+  beforeEach(() => {
+    query = {
+      msgId: '00000000-0000-0000-0000-000000000000',
+      status: 'pending',
+      tag: 'tag',
+      txId: '00000000-0000-0000-0000-000000000000'
+    };
+  });
 
   afterEach(() => {
-    ChesService.prototype.findCancelMessages.mockClear();
+    spy.mockClear();
   });
 
   it('should respond with an acknowledgement when a message is found', async () => {
     spy.mockResolvedValue(undefined);
-    const query = {
-      msgId: '00000000-0000-0000-0000-000000000000'
-    };
+    delete query.status;
+    delete query.tag;
+    delete query.txId;
 
     const response = await request(app).delete(`${basePath}`).query(query);
     expect(response.statusCode).toBe(202);
@@ -35,12 +45,6 @@ describe(`DELETE ${basePath}`, () => {
 
   it('should respond with an acknowledgement when multiple messages are found', async () => {
     spy.mockResolvedValue(undefined);
-    const query = {
-      msgId: '00000000-0000-0000-0000-000000000000',
-      status: 'pending',
-      tag: 'tag',
-      txId: '00000000-0000-0000-0000-000000000000'
-    };
 
     const response = await request(app).delete(`${basePath}`).query(query);
     expect(response.statusCode).toBe(202);
@@ -52,12 +56,7 @@ describe(`DELETE ${basePath}`, () => {
 
   it('should respond with an acknowledgement when nothing is found', async () => {
     spy.mockResolvedValue(undefined);
-    const query = {
-      msgId: '00000000-0000-0000-0000-000000000000',
-      status: 'accepted',
-      tag: 'tag',
-      txId: '00000000-0000-0000-0000-000000000000'
-    };
+    query.status = 'accepted';
 
     const response = await request(app).delete(`${basePath}`).query(query);
 
@@ -70,12 +69,6 @@ describe(`DELETE ${basePath}`, () => {
 
   it('should respond with an internal server error', async () => {
     const errorMsg = 'error';
-    const query = {
-      msgId: '00000000-0000-0000-0000-000000000000',
-      status: 'pending',
-      tag: 'tag',
-      txId: '00000000-0000-0000-0000-000000000000'
-    };
     spy.mockImplementation(() => {
       throw new Error(errorMsg);
     });
@@ -89,7 +82,7 @@ describe(`DELETE ${basePath}`, () => {
     expect(spy).toHaveBeenCalledWith(undefined, query.msgId, query.status, query.tag, query.txId);
   });
 
-  it.skip('should respond with a validation error', async () => {
+  it('should respond with a validation error', async () => {
     const response = await request(app).delete(`${basePath}`);
 
     expect(response.statusCode).toBe(422);

--- a/app/tests/unit/routes/v1/merge.spec.js
+++ b/app/tests/unit/routes/v1/merge.spec.js
@@ -78,13 +78,7 @@ describe(`POST ${basePath}`, () => {
       messages: [{ msgId: 'qwerqwerqwerw', to: ['email@email.org'] }]
     });
 
-    const response = await request(app).post(`${basePath}`).send({
-      bodyType: 'text',
-      body: 'body',
-      contexts: contexts,
-      from: 'email@email.com',
-      subject: 'subject'
-    });
+    const response = await request(app).post(`${basePath}`).send(body);
 
     expect(response.statusCode).toBe(201);
     expect(response.body).toBeTruthy();
@@ -103,13 +97,7 @@ describe(`POST ${basePath}`, () => {
       throw new Error(errorMsg);
     });
 
-    const response = await request(app).post(`${basePath}`).send({
-      bodyType: 'text',
-      body: 'body',
-      contexts: contexts,
-      from: 'email@email.com',
-      subject: 'subject'
-    });
+    const response = await request(app).post(`${basePath}`).send(body);
 
     expect(response.statusCode).toBe(500);
     expect(response.body).toBeTruthy();

--- a/app/tests/unit/routes/v1/status.spec.js
+++ b/app/tests/unit/routes/v1/status.spec.js
@@ -58,22 +58,29 @@ const getMessageStatusHistory = msgId => {
 };
 
 describe(`GET ${basePath}`, () => {
-  afterEach(() => {
-    ChesService.prototype.findStatuses.mockClear();
-  });
+  const spy = ChesService.prototype.findStatuses;
+  let query;
 
-  it('should respond with an array of messages', async () => {
-    const id = '00000000-0000-0000-0000-000000000000';
-    ChesService.prototype.findStatuses.mockResolvedValue([
-      getMessageStatus(id)
-    ]);
-
-    const response = await request(app).get(`${basePath}`).query({
+  beforeEach(() => {
+    query = {
       msgId: '00000000-0000-0000-0000-000000000000',
       status: 'completed',
       tag: 'tag',
       txId: '00000000-0000-0000-0000-000000000000'
-    });
+    };
+  });
+
+  afterEach(() => {
+    spy.mockClear();
+  });
+
+  it('should respond with an array of messages', async () => {
+    const id = '00000000-0000-0000-0000-000000000000';
+    spy.mockResolvedValue([
+      getMessageStatus(id)
+    ]);
+
+    const response = await request(app).get(`${basePath}`).query(query);
 
     expect(response.statusCode).toBe(200);
     expect(response.body).toBeTruthy();
@@ -88,14 +95,9 @@ describe(`GET ${basePath}`, () => {
   });
 
   it('should respond with an empty array if nothing was found', async () => {
-    ChesService.prototype.findStatuses.mockResolvedValue([]);
+    spy.mockResolvedValue([]);
 
-    const response = await request(app).get(`${basePath}`).query({
-      msgId: '00000000-0000-0000-0000-000000000000',
-      status: 'completed',
-      tag: 'tag',
-      txId: '00000000-0000-0000-0000-000000000000'
-    });
+    const response = await request(app).get(`${basePath}`).query(query);
 
     expect(response.statusCode).toBe(200);
     expect(response.body).toBeTruthy();
@@ -105,16 +107,11 @@ describe(`GET ${basePath}`, () => {
 
   it('should respond with an internal server error', async () => {
     const errorMsg = 'error';
-    ChesService.prototype.findStatuses.mockImplementation(() => {
+    spy.mockImplementation(() => {
       throw new Error(errorMsg);
     });
 
-    const response = await request(app).get(`${basePath}`).query({
-      msgId: '00000000-0000-0000-0000-000000000000',
-      status: 'completed',
-      tag: 'tag',
-      txId: '00000000-0000-0000-0000-000000000000'
-    });
+    const response = await request(app).get(`${basePath}`).query(query);
 
     expect(response.statusCode).toBe(500);
     expect(response.body.title).toMatch('Internal Server Error');
@@ -134,13 +131,15 @@ describe(`GET ${basePath}`, () => {
 });
 
 describe(`GET ${basePath}/:msgId`, () => {
+  const spy = ChesService.prototype.getStatus;
+
   afterEach(() => {
-    ChesService.prototype.getStatus.mockClear();
+    spy.mockClear();
   });
 
   it('should respond with the state of a message', async () => {
     const id = '00000000-0000-0000-0000-000000000000';
-    ChesService.prototype.getStatus.mockResolvedValue(getMessageStatusHistory(id));
+    spy.mockResolvedValue(getMessageStatusHistory(id));
 
     const response = await request(app).get(`${basePath}/${id}`);
 
@@ -158,7 +157,7 @@ describe(`GET ${basePath}/:msgId`, () => {
 
   it('should respond with a not found error', async () => {
     const id = '00000000-0000-0000-0000-000000000000';
-    ChesService.prototype.getStatus.mockImplementation(() => {
+    spy.mockImplementation(() => {
       throw new Problem(404);
     });
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
This PR introduces queryable message cancel functionality to CHES.
* Add Content-Location header support to responses
* Update unit test to reduce redundant declarations
* Ensure test environment cleans up after each test appropriately
* Add validation enforcement on valid status state strings
<!-- Why is this change required? What problem does it solve? -->
This is needed in order to finish version 1 implementation of the CHES API as originally designed.
<!-- If it fixes an open issue, please link to the issue here. -->
[[SHOWCASE-344]](https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-344)

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the OpenAPI 3.0 `v*.api-spec.yaml` documentation (if appropriate)
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
