### PR TITLE
Force Patroni and Redis to reapply deployment configs every time

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -276,8 +276,7 @@ def deployStage(String stageEnv, String projectEnv, String hostRouteEnv) {
               def dcPatroniSecretTemplate = openshift.process('-f',
                 'openshift/patroni.secret.yaml',
                 "APP_DB_NAME=${APP_NAME}",
-                "INSTANCE=${JOB_NAME}",
-                "NAMESPACE=${projectEnv}"
+                "INSTANCE=${JOB_NAME}"
               )
 
               echo "Creating Patroni Secret..."
@@ -285,19 +284,16 @@ def deployStage(String stageEnv, String projectEnv, String hostRouteEnv) {
             }
 
             // Apply Patroni Database
-            if(openshift.selector('statefulset', "patroni-${JOB_NAME}").exists()) {
-              echo "Patroni Deployment already exists. Skipping..."
-            } else {
-              echo "Processing Patroni StatefulSet.."
-              def dcPatroniTemplate = openshift.process('-f',
-                'openshift/patroni.dc.yaml',
-                "INSTANCE=${JOB_NAME}"
-              )
+            echo "Processing Patroni StatefulSet.."
+            def dcPatroniTemplate = openshift.process('-f',
+              'openshift/patroni.dc.yaml',
+              "INSTANCE=${JOB_NAME}",
+              "NAMESPACE=${projectEnv}"
+            )
 
-              echo "Applying Patroni StatefulSet..."
-              def dcPatroni = openshift.apply(dcPatroniTemplate).narrow('statefulset')
-              dcPatroni.rollout().status('--watch=true')
-            }
+            echo "Applying Patroni StatefulSet..."
+            def dcPatroni = openshift.apply(dcPatroniTemplate).narrow('statefulset')
+            dcPatroni.rollout().status('--watch=true')
           },
 
           Redis: {
@@ -318,21 +314,17 @@ def deployStage(String stageEnv, String projectEnv, String hostRouteEnv) {
             }
 
             // Apply Redis Deployment
-            if(openshift.selector('dc', "redis-${JOB_NAME}").exists()) {
-              echo "Redis Deployment already exists. Skipping..."
-            } else {
-              echo "Processing DeploymentConfig Redis.."
-              def dcRedisTemplate = openshift.process('-f',
-                'openshift/redis.dc.yaml',
-                "REPO_NAME=${REPO_NAME}",
-                "JOB_NAME=${JOB_NAME}",
-                "APP_NAME=${APP_NAME}"
-              )
+            echo "Processing DeploymentConfig Redis.."
+            def dcRedisTemplate = openshift.process('-f',
+              'openshift/redis.dc.yaml',
+              "REPO_NAME=${REPO_NAME}",
+              "JOB_NAME=${JOB_NAME}",
+              "APP_NAME=${APP_NAME}"
+            )
 
-              echo "Applying Redis Deployment..."
-              def dcRedis = openshift.apply(dcRedisTemplate).narrow('dc')
-              dcRedis.rollout().status('--watch=true')
-            }
+            echo "Applying Redis Deployment..."
+            def dcRedis = openshift.apply(dcRedisTemplate).narrow('dc')
+            dcRedis.rollout().status('--watch=true')
           }
         )
       }

--- a/Jenkinsfile.cicd
+++ b/Jenkinsfile.cicd
@@ -255,21 +255,17 @@ def deployStage(String stageEnv, String projectEnv, String hostRouteEnv) {
             }
 
             // Apply Patroni Database
-            if(openshift.selector('dc', "patroni-${JOB_NAME}").exists()) {
-              echo "Patroni Deployment already exists. Skipping..."
-            } else {
-              echo "Processing Patroni StatefulSet.."
-              def dcPatroniTemplate = openshift.process('-f',
-                'openshift/patroni-ephemeral.dc.yaml',
-                "APP_NAME=${APP_NAME}",
-                "INSTANCE=${JOB_NAME}",
-                "NAMESPACE=${projectEnv}"
-              )
+            echo "Processing Patroni StatefulSet.."
+            def dcPatroniTemplate = openshift.process('-f',
+              'openshift/patroni-ephemeral.dc.yaml',
+              "APP_NAME=${APP_NAME}",
+              "INSTANCE=${JOB_NAME}",
+              "NAMESPACE=${projectEnv}"
+            )
 
-              echo "Applying Patroni StatefulSet..."
-              def dcPatroni = openshift.apply(dcPatroniTemplate).narrow('statefulset')
-              dcPatroni.rollout().status('--watch=true')
-            }
+            echo "Applying Patroni StatefulSet..."
+            def dcPatroni = openshift.apply(dcPatroniTemplate).narrow('statefulset')
+            dcPatroni.rollout().status('--watch=true')
           },
 
           Redis: {
@@ -290,21 +286,17 @@ def deployStage(String stageEnv, String projectEnv, String hostRouteEnv) {
             }
 
             // Apply Redis Deployment
-            if(openshift.selector('dc', "redis-${JOB_NAME}").exists()) {
-              echo "Redis Deployment already exists. Skipping..."
-            } else {
-              echo "Processing DeploymentConfig Redis.."
-              def dcRedisTemplate = openshift.process('-f',
-                'openshift/redis-ephemeral.dc.yaml',
-                "REPO_NAME=${REPO_NAME}",
-                "JOB_NAME=${JOB_NAME}",
-                "APP_NAME=${APP_NAME}"
-              )
+            echo "Processing DeploymentConfig Redis.."
+            def dcRedisTemplate = openshift.process('-f',
+              'openshift/redis-ephemeral.dc.yaml',
+              "REPO_NAME=${REPO_NAME}",
+              "JOB_NAME=${JOB_NAME}",
+              "APP_NAME=${APP_NAME}"
+            )
 
-              echo "Applying Redis Deployment..."
-              def dcRedis = openshift.apply(dcRedisTemplate).narrow('dc')
-              dcRedis.rollout().status('--watch=true')
-            }
+            echo "Applying Redis Deployment..."
+            def dcRedis = openshift.apply(dcRedisTemplate).narrow('dc')
+            dcRedis.rollout().status('--watch=true')
           }
         )
       }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
If this is not done, existing patroni and redis instances will not be updated and redeployed.
<!-- Why is this change required? What problem does it solve? -->
NSPs never came into effect as it was skipped.
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the OpenAPI 3.0 `v*.api-spec.yaml` documentation (if appropriate)
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
