### PR TITLE
Change redis liveness probe to use redis-cli

### DIFF
--- a/openshift/redis-ephemeral.dc.yaml
+++ b/openshift/redis-ephemeral.dc.yaml
@@ -31,12 +31,16 @@ objects:
         - image: docker-registry.default.svc:5000/openshift/redis:latest
           imagePullPolicy: IfNotPresent
           livenessProbe:
+            exec:
+              command:
+              - "/bin/sh"
+              - "-i"
+              - "-c"
+              - test "$(redis-cli -h 127.0.0.1 -a $REDIS_PASSWORD ping)" == "PONG"
             failureThreshold: 3
             initialDelaySeconds: 30
             periodSeconds: 10
             successThreshold: 1
-            tcpSocket:
-              port: 6379
             timeoutSeconds: 1
           name: "redis-${JOB_NAME}"
           ports:

--- a/openshift/redis.dc.yaml
+++ b/openshift/redis.dc.yaml
@@ -31,12 +31,16 @@ objects:
         - image: docker-registry.default.svc:5000/openshift/redis:latest
           imagePullPolicy: IfNotPresent
           livenessProbe:
+            exec:
+              command:
+              - "/bin/sh"
+              - "-i"
+              - "-c"
+              - test "$(redis-cli -h 127.0.0.1 -a $REDIS_PASSWORD ping)" == "PONG"
             failureThreshold: 3
             initialDelaySeconds: 30
             periodSeconds: 10
             successThreshold: 1
-            tcpSocket:
-              port: 6379
             timeoutSeconds: 1
           name: "redis-${JOB_NAME}"
           ports:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
This PR attempts to ensure that when Redis is not running, Openshift will restart the container correctly.
<!-- Why is this change required? What problem does it solve? -->
We want to avoid the situation where Redis has exited, but the container doesn't terminate and hangs in limbo instead.
<!-- If it fixes an open issue, please link to the issue here. -->
[SHOWCASE-755](https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-755)

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the OpenAPI 3.0 `v*.api-spec.yaml` documentation (if appropriate)
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
Test this on Openshift by opening a terminal on redis-pr-39 container and then executing `kill -15 1`. This sends a SIGTERM to the init process (which is running Redis) and tells the application to kill itself. If this is working correctly, container should back-off and restart again shortly. Previously, a SIGTERM would happen, but the container would never clean up.