### PR TITLE
Change Patroni default storage class to netapp-block-standard

### DIFF
--- a/openshift/patroni.dc.yaml
+++ b/openshift/patroni.dc.yaml
@@ -359,4 +359,4 @@ parameters:
   description: The type of the persistent volume to create.
   displayName: Persistent Volume Class
   required: true
-  value: gluster-block
+  value: netapp-block-standard


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
Since the platform needs to change from GlusterFS to netapp, we need to migrate our existing PVCs to the new system.
<!-- Why is this change required? What problem does it solve? -->
This is needed as GlusterFS is deprecated and will disappear at some point in the future.
<!-- If it fixes an open issue, please link to the issue here. -->
[SHOWCASE-795](https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-795)

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the OpenAPI 3.0 `v*.api-spec.yaml` documentation (if appropriate)
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
Migration work has been done out of band. This PR is to ensure subsequent Patroni deployments remain in alignment with what is deployed.