### PR TITLE
When delayTS is explicitly set to null, it borks the delivery.

### DIFF
--- a/app/src/components/utils.js
+++ b/app/src/components/utils.js
@@ -39,15 +39,15 @@ const utils = {
   },
 
   /** @function filterUndefinedAndEmptyArray
-   *  @description Returns a new object where undefined and empty arrays are dropped
+   *  @description Returns a new object where null/undefined, and null/empty arrays are dropped
    *
    *  @param {object} obj A JSON Object
-   *  @returns {object} A JSON Object without empty arrays and undefined properties
+   *  @returns {object} A JSON Object without null/empty arrays and null/undefined properties
    */
   filterUndefinedAndEmptyArray: obj => {
     const ret = {};
     Object.keys(obj)
-      .filter((key) => obj[key] !== undefined && obj[key].length)
+      .filter((key) => obj[key] !== undefined && obj[key] && obj[key].length)
       .forEach((key) => ret[key] = obj[key]);
     return ret;
   },

--- a/app/tests/unit/components/utils.spec.js
+++ b/app/tests/unit/components/utils.spec.js
@@ -76,7 +76,8 @@ describe('filterUndefinedAndEmptyArray', () => {
     baz: [
       'herp'
     ],
-    derp: 'flerp'
+    derp: 'flerp',
+    whoops: null
   };
 
   it('should drop undefined properties', () => {
@@ -84,6 +85,7 @@ describe('filterUndefinedAndEmptyArray', () => {
 
     expect(result).toBeTruthy();
     expect(result.foo).toBeUndefined();
+    expect(result.whoops).toBeUndefined();
     expect(result.derp).toMatch('flerp');
     expect(Object.keys(result).length).toEqual(2);
   });

--- a/app/tests/unit/components/validators.spec.js
+++ b/app/tests/unit/components/validators.spec.js
@@ -332,6 +332,12 @@ describe('models.context.cc', () => {
 
 describe('models.context.delayTS', () => {
 
+  it('should return true for null', () => {
+    const value = null;
+    const result = models.context.delayTS(value);
+    expect(result).toBeTruthy();
+  });
+
   it('should return true for undefined', () => {
     const value = undefined;
     const result = models.context.delayTS(value);


### PR DESCRIPTION
Should be handled and treated the same as undefined or 0.
Issue was a utility function didn't handle null.  The actual delay was fine and handled like 0.
The utility function is only called in one place, so toss up of where to put the fix.

[SHOWCASE-1332](https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-1332)

<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the OpenAPI 3.0 `v*.api-spec.yaml` documentation (if appropriate)
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
