### PR TITLE
Change DB Connection probe to detect read-only state

### DIFF
--- a/app/src/services/dataConn.js
+++ b/app/src/services/dataConn.js
@@ -72,13 +72,15 @@ class DataConnection {
   /**
    *  @function checkConnection
    *  Checks the current knex connection to Postgres
+   *  If the connected DB is in read-only mode, transaction_read_only will not be off
    *  @returns {boolean} True if successful, otherwise false
    */
   async checkConnection() {
     try {
-      const data = await this._knex.raw('SELECT 1+1 AS result');
-      const result = data && data.rows && data.rows[0].result === 2;
+      const data = await this.knex.raw('show transaction_read_only');
+      const result = data && data.rows && data.rows[0].transaction_read_only === 'off';
       if (result) log.verbose('DataConnection.checkConnection', 'Database connection ok');
+      else log.warn('DataConnection.checkConnection', 'Database connection is read-only');
       return result;
     } catch (err) {
       log.error('DataConnection.checkConnection', `Error with database connection: ${err.message}`);


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
This PR makes it so that the periodic DB connection checks if the DB is Postgres, whether DB is queryable, and if DB is not in read-only mode.
<!-- Why is this change required? What problem does it solve? -->
As our DB is managed by Patroni for High Availability, there may be rare edge cases where CHES may retain a connection to a non-master node of Postgres. When this happens, any transactions needing to write to the database will fail because it is connected to a read-only instance. We want the container to fail fast and exit out so that it can be restored in a new pod connecting to the right DB instance as soon as the read-only state is detected.
<!-- If it fixes an open issue, please link to the issue here. -->
[SHOWCASE-1478](https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-1478)

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the OpenAPI 3.0 `v*.api-spec.yaml` documentation (if appropriate)
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
Inspiration from following SO thread: https://stackoverflow.com/a/9277406