### PR TITLE
Modify read transaction query

### DIFF
--- a/app/src/services/dataSvc.js
+++ b/app/src/services/dataSvc.js
@@ -246,9 +246,7 @@ class DataService {
       .findById(transactionId)
       .where('client', client)
       .withGraphJoined('messages.statusHistory')
-      .modifyGraph('messages.statusHistory', builder => {
-        builder.orderBy('createdAt', 'desc');
-      })
+      .orderBy('messages:statusHistory.createdAt', 'desc')
       .throwIfNotFound();
   }
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description
After merging this will do further confirmation in TEST env before prod deployment.

Long investigation, tiny change.
Prod CHES has been getting progressively slower on message POST as the database gets fuller. Traced the database heaviness to the readTransaction call to return transaction detail.

It joins the statuses for the messages, but does a sort on the inner query that a join is being done on, causing query plan complexity that weighs a lot when status has many records (like on prod).
This sort isn't necessary for posting the message (or posting a merge of many messages), and this readTransaction call is only being done on those 2 posts (**the status endpoints use different queries**), so it's safe to move it out of the inner query after testing.

See further comments below for details.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the OpenAPI 3.0 `v*.api-spec.yaml` documentation (if appropriate)
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
All investigation related to DB calls, potentially Redis could have performance improvements, but fixing the 1 query appears to ameliorate the slowness when tested against production data set.

In `dataSvc.createTransaction` traced all the time coming from `const result = await this.readTransaction(client, transactionId);`
See changes in this PR for what changed in there.

The original query yielded the following sql

```
select
	"trxn"."transactionId" as "transactionId",
	"trxn"."client" as "client",
	"trxn"."createdAt" as "createdAt",
	"trxn"."updatedAt" as "updatedAt",
	"messages"."messageId" as "messages:messageId",
	"messages"."transactionId" as "messages:transactionId",
	"messages"."tag" as "messages:tag",
	"messages"."delayTimestamp" as "messages:delayTimestamp",
	"messages"."status" as "messages:status",
	"messages"."email" as "messages:email",
	"messages"."sendResult" as "messages:sendResult",
	"messages"."createdAt" as "messages:createdAt",
	"messages"."updatedAt" as "messages:updatedAt",
	"messages:statusHistory"."statusId" as "messages:statusHistory:statusId",
	"messages:statusHistory"."messageId" as "messages:statusHistory:messageId",
	"messages:statusHistory"."status" as "messages:statusHistory:status",
	"messages:statusHistory"."description" as "messages:statusHistory:description",
	"messages:statusHistory"."createdAt" as "messages:statusHistory:createdAt"
from
	"trxn"
left join "message" as "messages" on
	"messages"."transactionId" = "trxn"."transactionId"
left join (
	select
		"status" .*
	from
		"status"
	order by
		"createdAt" desc) as "messages:statusHistory" on
	"messages:statusHistory"."messageId" = "messages"."messageId"
where
	"trxn"."transactionId" = ?
	and "client" = ?
```
With this execution plan
![image](https://user-images.githubusercontent.com/17445138/104974877-09e33980-59ae-11eb-8a89-5ad00a8c826e.png)


And the change

```
select
	"trxn"."transactionId" as "transactionId",
	"trxn"."client" as "client",
	"trxn"."createdAt" as "createdAt",
	"trxn"."updatedAt" as "updatedAt",
	"messages"."messageId" as "messages:messageId",
	"messages"."transactionId" as "messages:transactionId",
	"messages"."tag" as "messages:tag",
	"messages"."delayTimestamp" as "messages:delayTimestamp",
	"messages"."status" as "messages:status",
	"messages"."email" as "messages:email",
	"messages"."sendResult" as "messages:sendResult",
	"messages"."createdAt" as "messages:createdAt",
	"messages"."updatedAt" as "messages:updatedAt",
	"messages:statusHistory"."statusId" as "messages:statusHistory:statusId",
	"messages:statusHistory"."messageId" as "messages:statusHistory:messageId",
	"messages:statusHistory"."status" as "messages:statusHistory:status",
	"messages:statusHistory"."description" as "messages:statusHistory:description",
	"messages:statusHistory"."createdAt" as "messages:statusHistory:createdAt"
from
	"trxn"
left join "message" as "messages" on
	"messages"."transactionId" = "trxn"."transactionId"
left join "status" as "messages:statusHistory" on
	"messages:statusHistory"."messageId" = "messages"."messageId"
where
	"trxn"."transactionId" = ?
	and "client" = ?
order by
	"messages:statusHistory"."createdAt" desc
```
With this execution plan
![image](https://user-images.githubusercontent.com/17445138/104974888-1071b100-59ae-11eb-931c-1f5a88984391.png)


I don't believe that final order by is actually necessary, since the read transaction only cares about the single transaction that was immediately just done. But kept it in (since it's no cost being done on the result set of the single transaction) to preserve the result being exactly the same as before. Maybe paranoid but shouldn't harm