### PR TITLE
Return SMTP response in status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Common Hosted Email Service [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE) [![Quality Gate](https://sonarqube-9f0fbe-tools.pathfinder.gov.bc.ca/api/badges/gate?key=common-hosted-email-service-master)](https://sonarqube-9f0fbe-tools.pathfinder.gov.bc.ca/dashboard?id=common-hosted-email-service-master)
+# Common Hosted Email Service [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE) [![Quality Gate](https://sonarqube-9f0fbe-tools.pathfinder.gov.bc.ca/api/badges/gate?key=common-hosted-email-service-master)](https://sonarqube-9f0fbe-tools.pathfinder.gov.bc.ca/dashboard?id=common-hosted-email-service-master) [![img](https://img.shields.io/badge/Lifecycle-Stable-97ca00)](https://github.com/bcgov/repomountie/blob/master/doc/lifecycle-badges.md)
 
 [![Bugs](https://sonarqube-9f0fbe-tools.pathfinder.gov.bc.ca/api/badges/measure?key=common-hosted-email-service-master&metric=bugs)](https://sonarqube-9f0fbe-tools.pathfinder.gov.bc.ca/dashboard?id=common-hosted-email-service-master)
 [![Vulnerabilities](https://sonarqube-9f0fbe-tools.pathfinder.gov.bc.ca/api/badges/measure?key=common-hosted-email-service-master&metric=vulnerabilities)](https://sonarqube-9f0fbe-tools.pathfinder.gov.bc.ca/dashboard?id=common-hosted-email-service-master)
@@ -6,6 +6,8 @@
 [![Coverage](https://sonarqube-9f0fbe-tools.pathfinder.gov.bc.ca/api/badges/measure?key=common-hosted-email-service-master&metric=coverage)](https://sonarqube-9f0fbe-tools.pathfinder.gov.bc.ca/dashboard?id=common-hosted-email-service-master)
 [![Lines](https://sonarqube-9f0fbe-tools.pathfinder.gov.bc.ca/api/badges/measure?key=common-hosted-email-service-master&metric=lines)](https://sonarqube-9f0fbe-tools.pathfinder.gov.bc.ca/dashboard?id=common-hosted-email-service-master)
 [![Duplication](https://sonarqube-9f0fbe-tools.pathfinder.gov.bc.ca/api/badges/measure?key=common-hosted-email-service-master&metric=duplicated_lines_density)](https://sonarqube-9f0fbe-tools.pathfinder.gov.bc.ca/dashboard?id=common-hosted-email-service-master)
+
+
 
 CHES - Powered by NodeMailer (a shared library)
 

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -3811,9 +3811,9 @@
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "ini": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
     },
     "interpret": {
       "version": "2.2.0",

--- a/app/src/components/transformer.js
+++ b/app/src/components/transformer.js
@@ -20,6 +20,7 @@ const transformer = {
       createdTS: msg.createdAt ? moment.utc(msg.createdAt).valueOf() : null,
       delayTS: msg.delayTimestamp ? moment.utc(Number(msg.delayTimestamp)).valueOf() : null,
       msgId: msg.messageId ? msg.messageId : null,
+      smtpResponse: msg.sendResult ? msg.sendResult : null,
       status: msg.status ? msg.status : null,
       statusHistory: msg.statusHistory ? msg.statusHistory.map(h => {
         return {

--- a/app/src/docs/v1.api-spec.yaml
+++ b/app/src/docs/v1.api-spec.yaml
@@ -742,6 +742,18 @@ components:
         detail:
           type: string
           description: Short description of why this problem was raised.
+    SmtpObject:
+      type: object
+      description: The saved response object from the SMTP server if applicable
+      properties:
+        smtpMsgId:
+          type: string
+          description: The downstream smtp ID from the server
+          example: '<11111111-1111-1111-1111-111111111111@gov.bc.ca>'
+        response:
+          type: string
+          description: The downstream response message from the server
+          example: '250 2.6.0 <11111111-1111-1111-1111-111111111111@gov.bc.ca> [InternalId=82420422419525, Hostname=E6PEDG05.idir.BCGOV] 1464 bytes in 0.225, 6.333 KB/sec Queued mail for delivery'
     StatusHistoryObject:
       type: array
       description: A list of status changes to this message
@@ -766,6 +778,7 @@ components:
         - createdTS
         - delayTS
         - msgId
+        - smtpResponse
         - status
         - statusHistory
         - tag
@@ -787,6 +800,8 @@ components:
           description: This message instance uuid
           format: uuid
           example: 00000000-0000-0000-0000-000000000000
+        smtpResponse:
+          $ref: '#/components/schemas/SmtpObject'
         status:
           $ref: '#/components/schemas/StatusType'
         statusHistory:

--- a/app/tests/unit/components/transformer.spec.js
+++ b/app/tests/unit/components/transformer.spec.js
@@ -8,10 +8,11 @@ helper.logHelper();
 describe('toStatusResponse', () => {
   const nullPopulatedExpectations = result => {
     expect(result).toBeTruthy();
-    expect(Object.keys(result)).toHaveLength(8);
+    expect(Object.keys(result)).toHaveLength(9);
     expect(result.createdTS).toBeNull();
     expect(result.delayTS).toBeNull();
     expect(result.msgId).toBeNull();
+    expect(result.smtpResponse).toBeNull();
     expect(result.status).toBeNull();
     expect(Array.isArray(result.statusHistory)).toBeTruthy();
     expect(result.statusHistory).toHaveLength(0);
@@ -50,7 +51,7 @@ describe('toStatusResponse', () => {
     });
 
     expect(result).toBeTruthy();
-    expect(Object.keys(result)).toHaveLength(8);
+    expect(Object.keys(result)).toHaveLength(9);
     expect(result.createdTS).toBe(1571679721833);
   });
 
@@ -60,7 +61,7 @@ describe('toStatusResponse', () => {
     });
 
     expect(result).toBeTruthy();
-    expect(Object.keys(result)).toHaveLength(8);
+    expect(Object.keys(result)).toHaveLength(9);
     expect(result.delayTS).toBe(0);
   });
 
@@ -70,9 +71,21 @@ describe('toStatusResponse', () => {
     });
 
     expect(result).toBeTruthy();
-    expect(Object.keys(result)).toHaveLength(8);
+    expect(Object.keys(result)).toHaveLength(9);
     expect(result.msgId).toBe('00000000-0000-0000-0000-000000000000');
   });
+
+  it('should return an object with smtpResponse', () => {
+    const smtp = '{"smtpMsgId": "<00000000-0000-0000-0000-000000000000@gov.bc.ca>","response": "250 2.6.0 <00000000-0000-0000-0000-000000000000@gov.bc.ca> [InternalId=abc, Hostname=E6PEDG06.idir.BCGOV] 4596 bytes in 0.105, 42.525 KB/sec Queued mail for delivery"}';
+    const result = transformer.toStatusResponse({
+      sendResult: smtp
+    });
+
+    expect(result).toBeTruthy();
+    expect(Object.keys(result)).toHaveLength(9);
+    expect(result.smtpResponse).toBe(smtp);
+  });
+
 
   it('should return an object with status', () => {
     const result = transformer.toStatusResponse({
@@ -80,7 +93,7 @@ describe('toStatusResponse', () => {
     });
 
     expect(result).toBeTruthy();
-    expect(Object.keys(result)).toHaveLength(8);
+    expect(Object.keys(result)).toHaveLength(9);
     expect(result.status).toBe('completed');
   });
 
@@ -99,7 +112,7 @@ describe('toStatusResponse', () => {
     });
 
     expect(result).toBeTruthy();
-    expect(Object.keys(result)).toHaveLength(8);
+    expect(Object.keys(result)).toHaveLength(9);
     expect(result.statusHistory).toHaveLength(2);
     expect(result.statusHistory[0].description).toBe('text');
     expect(result.statusHistory[0].status).toBe('stuff');
@@ -112,7 +125,7 @@ describe('toStatusResponse', () => {
     });
 
     expect(result).toBeTruthy();
-    expect(Object.keys(result)).toHaveLength(8);
+    expect(Object.keys(result)).toHaveLength(9);
     expect(result.tag).toBe('tag');
   });
 
@@ -122,7 +135,7 @@ describe('toStatusResponse', () => {
     });
 
     expect(result).toBeTruthy();
-    expect(Object.keys(result)).toHaveLength(8);
+    expect(Object.keys(result)).toHaveLength(9);
     expect(result.txId).toBe('00000000-0000-0000-0000-000000000000');
   });
 
@@ -132,7 +145,7 @@ describe('toStatusResponse', () => {
     });
 
     expect(result).toBeTruthy();
-    expect(Object.keys(result)).toHaveLength(8);
+    expect(Object.keys(result)).toHaveLength(9);
     expect(result.updatedTS).toBe(1571679721833);
   });
 });


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description
Add the smtp response to the Status calls to facilitate troubleshooting.
https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-1151

This field is public.message.sendResult in the DB and is populated when the message is set to completed.

Since this is an additive change to a status endpoint I don't think we need to worry about any API versioning on this change.

Leaving draft. If reviews look good will set up some test data before merge on monday.

Add badge (#62) and `npm audit fix` as well

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
Documentation (non-breaking change with enhancements to documentation)
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the OpenAPI 3.0 `v*.api-spec.yaml` documentation (if appropriate)
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
