### PR TITLE
Add sso public key to app cache

### DIFF
--- a/app/config/custom-environment-variables.json
+++ b/app/config/custom-environment-variables.json
@@ -8,6 +8,7 @@
   "keycloak": {
     "clientId": "KC_CLIENTID",
     "clientSecret": "KC_CLIENTSECRET",
+    "publicKey": "SERVER_KC_PUBLICKEY",
     "realm": "KC_REALM",
     "serverUrl": "KC_SERVERURL"
   },

--- a/app/config/custom-environment-variables.json
+++ b/app/config/custom-environment-variables.json
@@ -8,7 +8,7 @@
   "keycloak": {
     "clientId": "KC_CLIENTID",
     "clientSecret": "KC_CLIENTSECRET",
-    "publicKey": "SERVER_KC_PUBLICKEY",
+    "publicKey": "KC_PUBLICKEY",
     "realm": "KC_REALM",
     "serverUrl": "KC_SERVERURL"
   },

--- a/app/src/components/keycloak.js
+++ b/app/src/components/keycloak.js
@@ -7,6 +7,7 @@ module.exports = new Keycloak({}, {
   clientId: config.get('keycloak.clientId'),
   'policy-enforcer': {},
   realm: config.get('keycloak.realm'),
+  realmPublicKey: config.has('keycloak.publicKey') ? config.get('keycloak.publicKey') : undefined,
   secret: config.get('keycloak.clientSecret'),
   serverUrl: config.get('keycloak.serverUrl'),
   'ssl-required': 'external',

--- a/openshift/README.md
+++ b/openshift/README.md
@@ -23,6 +23,8 @@ In order to prepare an environment, you will need to ensure that all of the foll
 
 *Note: Replace anything in angle brackets with the appropriate value!*
 
+*Note 2:* The Keycloak Public Key can be found in the Keycloak Admin Panel under Realm Settings > Keys. Look for the Public key button (normally under RS256 row), and click to see the key. The key should begin with a pattern of `MIIBIjANB...`.
+
 ```sh
 oc create -n 9f0fbe-<env> configmap ches-keycloak-config \
   --from-literal=KC_REALM=jbd6rnxw \
@@ -32,9 +34,12 @@ oc create -n 9f0fbe-<env> configmap ches-keycloak-config \
 *Note: Change KC_SERVERURL's sso-dev to sso-test or sso depending on the environment!*
 
 ```sh
+export PUBLIC_KEY=<yourkeycloakpublickey>
+
 oc create -n 9f0fbe-<env> configmap ches-server-config \
   --from-literal=SERVER_ATTACHMENTLIMIT=20mb \
   --from-literal=SERVER_BODYLIMIT=100mb \
+  --from-literal=SERVER_KC_PUBLICKEY=$PUBLIC_KEY \
   --from-literal=SERVER_LOGLEVEL=info \
   --from-literal=SERVER_MORGANFORMAT=combined \
   --from-literal=SERVER_PORT=3000 \

--- a/openshift/README.md
+++ b/openshift/README.md
@@ -26,20 +26,20 @@ In order to prepare an environment, you will need to ensure that all of the foll
 *Note 2:* The Keycloak Public Key can be found in the Keycloak Admin Panel under Realm Settings > Keys. Look for the Public key button (normally under RS256 row), and click to see the key. The key should begin with a pattern of `MIIBIjANB...`.
 
 ```sh
+export PUBLIC_KEY=<yourkeycloakpublickey>
+
 oc create -n 9f0fbe-<env> configmap ches-keycloak-config \
   --from-literal=KC_REALM=jbd6rnxw \
   --from-literal=KC_SERVERURL=https://dev.oidc.gov.bc.ca/auth
+  --from-literal=KC_PUBLICKEY=$PUBLIC_KEY \
 ```
 
 *Note: Change KC_SERVERURL's sso-dev to sso-test or sso depending on the environment!*
 
 ```sh
-export PUBLIC_KEY=<yourkeycloakpublickey>
-
 oc create -n 9f0fbe-<env> configmap ches-server-config \
   --from-literal=SERVER_ATTACHMENTLIMIT=20mb \
   --from-literal=SERVER_BODYLIMIT=100mb \
-  --from-literal=SERVER_KC_PUBLICKEY=$PUBLIC_KEY \
   --from-literal=SERVER_LOGLEVEL=info \
   --from-literal=SERVER_MORGANFORMAT=combined \
   --from-literal=SERVER_PORT=3000 \


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description
- Backend behaves statelessly for JWT verification when realmPublicKey is supplied
- Without realmPublicKey, backend must call OIDC endpoint first


## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [ ] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the OpenAPI 3.0 `v*.api-spec.yaml` documentation (if appropriate)
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
