### PR TITLE
Attempt to refresh DB pool connections on 500 error

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -164,7 +164,9 @@ process.on('SIGINT', shutdown);
 function shutdown() {
   log.info('Received kill signal. Shutting down...');
   state.shutdown = true;
-  QueueConnection.close();
+  dataConnection.close();
+  queueConnection.close();
+
   // Wait 3 seconds before hard exiting
   setTimeout(() => process.exit(), 3000);
 }

--- a/app/app.js
+++ b/app/app.js
@@ -125,6 +125,9 @@ app.use(/(\/api)?/, apiRouter);
 // Handle 500
 // eslint-disable-next-line no-unused-vars
 app.use((err, _req, res, _next) => {
+  // Attempt to reset DB connection
+  dataConnection.resetConnection();
+
   if (err.stack) {
     log.error(err.stack);
   }
@@ -143,7 +146,7 @@ app.use((_req, res) => {
   new Problem(404).send(res);
 });
 
-// Prevent unhandled errors from crashing application
+// Prevent unhandled promise errors from crashing application
 process.on('unhandledRejection', err => {
   if (err && err.stack) {
     log.error(err.stack);

--- a/app/src/services/dataConn.js
+++ b/app/src/services/dataConn.js
@@ -31,23 +31,26 @@ class DataConnection {
     return DataConnection.instance;
   }
 
-  /** @function connected
-   *  True or false if connected.
+  /**
+   * @function connected
+   * True or false if connected.
    */
   get connected() {
     return this._connected;
   }
 
-  /** @function knex
-   *  Gets the current knex binding
+  /**
+   * @function knex
+   * Gets the current knex binding
    */
   get knex() {
     return this._knex;
   }
 
-  /** @function knex
-   *  Sets the current knex binding
-   *  @param {object} v - a Knex object.
+  /**
+   * @function knex
+   * Sets the current knex binding
+   * @param {object} v - a Knex object.
    */
   set knex(v) {
     this._knex = v;
@@ -55,9 +58,9 @@ class DataConnection {
   }
 
   /**
-   *  @function checkAll
-   *  Checks the Knex connection, the database schema, and Objection models
-   *  @returns {boolean} True if successful, otherwise false
+   * @function checkAll
+   * Checks the Knex connection, the database schema, and Objection models
+   * @returns {boolean} True if successful, otherwise false
    */
   async checkAll() {
     const connectOk = await this.checkConnection();
@@ -70,10 +73,10 @@ class DataConnection {
   }
 
   /**
-   *  @function checkConnection
-   *  Checks the current knex connection to Postgres
-   *  If the connected DB is in read-only mode, transaction_read_only will not be off
-   *  @returns {boolean} True if successful, otherwise false
+   * @function checkConnection
+   * Checks the current knex connection to Postgres
+   * If the connected DB is in read-only mode, transaction_read_only will not be off
+   * @returns {boolean} True if successful, otherwise false
    */
   async checkConnection() {
     try {
@@ -89,9 +92,9 @@ class DataConnection {
   }
 
   /**
-   *  @function checkSchema
-   *  Queries the knex connection to check for the existence of the expected schema tables
-   *  @returns {boolean} True if schema is ok, otherwise false
+   * @function checkSchema
+   * Queries the knex connection to check for the existence of the expected schema tables
+   * @returns {boolean} True if schema is ok, otherwise false
    */
   checkSchema() {
     const tables = ['trxn', 'message', 'status', 'queue'];
@@ -111,9 +114,9 @@ class DataConnection {
   }
 
   /**
-   *  @function checkModel
-   *  Attaches the Objection model to the existing knex connection
-   *  @returns {boolean} True if successful, otherwise false
+   * @function checkModel
+   * Attaches the Objection model to the existing knex connection
+   * @returns {boolean} True if successful, otherwise false
    */
   checkModel() {
     try {
@@ -125,6 +128,17 @@ class DataConnection {
       log.error('DataConnection.checkModel', err);
       return false;
     }
+  }
+
+  /**
+   * @function resetConnection
+   * Invalidates and reconnects existing knex connection
+   */
+  resetConnection() {
+    log.warn('DataConnection.resetConnection', 'Attempting to reset database connection pool...');
+    this.knex.destroy(() => {
+      this.knex.initialize();
+    });
   }
 }
 

--- a/app/src/services/dataConn.js
+++ b/app/src/services/dataConn.js
@@ -131,6 +131,22 @@ class DataConnection {
   }
 
   /**
+   * @function close
+   * Will close the DataConnection
+   */
+  close() {
+    if (this.knex) {
+      try {
+        this.knex.destroy();
+        this._connected = false;
+        log.info('DataConnection.close', 'Disconnected');
+      } catch (e) {
+        log.error(e);
+      }
+    }
+  }
+
+  /**
    * @function resetConnection
    * Invalidates and reconnects existing knex connection
    */

--- a/app/src/services/queueConn.js
+++ b/app/src/services/queueConn.js
@@ -39,13 +39,13 @@ const _createClient = () => {
   }
 
   redis.on('ready', () => {
-    log.debug('QueueConnection', 'Redis Ready');
+    log.verbose('QueueConnection', 'Redis Ready');
   });
   redis.on('reconnecting', () => {
-    log.debug('QueueConnection', 'Redis Reconnecting...');
+    log.verbose('QueueConnection', 'Redis Reconnecting...');
   });
   redis.on('connect', () => {
-    log.debug('QueueConnection', 'Redis Connected');
+    log.verbose('QueueConnection', 'Redis Connected');
   });
 
   return redis;
@@ -134,7 +134,7 @@ class QueueConnection {
    * @function close
    * Will close the QueueConnection
    */
-  static close() {
+  close() {
     if (this.queue) {
       try {
         this.queue.close();


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
- Attempt to refresh DB pool connections when a 500 error occurs
- Change ioredis events to verbose
- Make QueueConnection.close non-static
- Ensure queue and data connections actually close before quitting
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
[SHOWCASE-2010](https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-2010)

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the OpenAPI 3.0 `v*.api-spec.yaml` documentation (if appropriate)
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
