### PR TITLE
CPU Limit increase and SMTP Pool timeout reduction

### DIFF
--- a/app/src/services/emailConn.js
+++ b/app/src/services/emailConn.js
@@ -28,6 +28,8 @@ class EmailConnection {
         rejectUnauthorized: false // do not fail on invalid certs
       },
       connectionTimeout: 10000, // Timeout SMTP connection attempt after 10 seconds
+      // Ref `Connection inactivity time`: https://docs.microsoft.com/en-us/exchange/mail-flow/message-rate-limits?view=exchserver-2019#message-throttling-on-receive-connectors
+      socketTimeout: 500000, // Close SMTP connection after 5 minutes of inactivity
       pool: true // Use pooled email connections to reduce TCP network churn
     };
   }

--- a/openshift/app.dc.yaml
+++ b/openshift/app.dc.yaml
@@ -332,7 +332,7 @@ parameters:
   - name: CPU_LIMIT
     description: Limit Peak CPU per pod (in millicores ex. 1000m)
     displayName: CPU Limit
-    value: 150m
+    value: 250m
   - name: CPU_REQUEST
     description: Requested CPU per pod (in millicores ex. 500m)
     displayName: CPU Request


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
- Set CPU limit back to 250m
- Set SMTP connection timeout to 5 minutes to match Microsoft Exchange server defaults ([Ref](https://docs.microsoft.com/en-us/exchange/mail-flow/message-rate-limits?view=exchserver-2019#message-throttling-on-receive-connectors))
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the OpenAPI 3.0 `v*.api-spec.yaml` documentation (if appropriate)
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
