### PR TITLE
Bugfix: Only reset DB connections if it is a 5xx class error

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -128,18 +128,17 @@ app.use(/(\/api)?/, apiRouter);
 // Handle 500
 // eslint-disable-next-line no-unused-vars
 app.use((err, _req, res, _next) => {
-  // Attempt to reset DB connection
-  if (!state.shutdown) {
-    dataConnection.resetConnection();
-  }
-
   if (err.stack) {
     log.error(err.stack);
   }
 
   if (err instanceof Problem) {
+    // Attempt to reset DB connection if 5xx error
+    if (err.status >= 500 && !state.shutdown) dataConnection.resetConnection();
     err.send(res);
   } else {
+    // Attempt to reset DB connection
+    if (!state.shutdown) dataConnection.resetConnection();
     new Problem(500, {
       details: (err.message) ? err.message : err
     }).send(res);


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
- Only reset DB connections if it is a 5xx class error
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
[SHOWCASE-2075](https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-2075)

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the OpenAPI 3.0 `v*.api-spec.yaml` documentation (if appropriate)
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
