### PR TITLE
Bugfix: Only attempt to parse azp from JWT token if it actually exists

### DIFF
--- a/app/src/middleware/authorizedParty.js
+++ b/app/src/middleware/authorizedParty.js
@@ -17,8 +17,13 @@ const log = require('../components/log')(module.filename);
  */
 async function authorizedParty(req, _res, next) {
   try {
-    const token = jwt.decode((req.get('authorization') || '').slice(7));
-    req.authorizedParty = token.azp;
+    const authorization = req.get('authorization');
+    if (authorization) {
+      const token = jwt.decode((req.get('authorization')).slice(7));
+      req.authorizedParty = token.azp;
+    } else {
+      req.authorizedParty = undefined;
+    }
   } catch (err) {
     log.error(err.message, { function: 'authorizedParty' });
     req.authorizedParty = undefined;


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
This PR ensures that the middleware should only attempt to parse azp from JWT token if it actually exists. (We don't want kube-probe error spam)
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
[SHOWCASE-2288](https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-2288)

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the OpenAPI 3.0 `v*.api-spec.yaml` documentation (if appropriate)
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
