### PR TITLE
Update Node to 20.9.0 LTS and bugfix npm eacces error

### DIFF
--- a/openshift/app.bc.yaml
+++ b/openshift/app.bc.yaml
@@ -43,12 +43,25 @@ objects:
         type: Git
         dockerfile: |-
           FROM BuildConfig
-          ENV NO_UPDATE_NOTIFIER=true
-          WORKDIR /opt/app-root/src
-          COPY . .
-          RUN npm ci
-          EXPOSE 3000
-          CMD ["npm", "run", "start"]
+
+          ARG APP_ROOT=/opt/app-root/src
+          ENV APP_PORT=3000 \
+              NO_UPDATE_NOTIFIER=true
+          WORKDIR ${APP_ROOT}
+
+          # NPM Permission Fix
+          RUN mkdir -p /.npm
+          RUN chown -R 1001:0 /.npm
+
+          # Install Application
+          COPY . ${APP_ROOT}/app
+          RUN chown -R 1001:0 ${APP_ROOT}
+          USER 1001
+          WORKDIR ${APP_ROOT}/app
+          RUN npm ci --omit=dev
+
+          EXPOSE ${APP_PORT}
+          CMD ["node", "./bin/www"]
       strategy:
         dockerStrategy:
           env:
@@ -58,7 +71,7 @@ objects:
               value: notice
           from:
             kind: DockerImage
-            name: docker.io/node:16.15.0-alpine
+            name: docker.io/node:20.9.0-alpine
         type: Docker
       successfulBuildsHistoryLimit: 3
 parameters:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
This PR addresses an operational issue where the `/.npm` root cache has problems being accessed by npm which is now preventing new pods from spinning up on Openshift. Also bumps Node from 16 to 20 LTS.
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [ ] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the OpenAPI 3.0 `v*.api-spec.yaml` documentation (if appropriate)
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
