### PR TITLE
Fix API doc link in README.md

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -158,7 +158,7 @@ npm run lint
 ## API Usage
 
 This API is defined and described in OpenAPI 3.0 specification.
-When the API is running, you should be able to view the specification through ReDoc at <http://localhost:3000/api/v1/docs> (assuming you are running this microservice locally). A hosted instance of the API can be found at: <https://ches.nrs.gov.bc.ca/api/v1/docs>
+When the API is running, you should be able to view the specification through ReDoc at <http://localhost:3000/api/v1/docs> (assuming you are running this microservice locally). A hosted instance of the API can be found at: <https://ches.api.gov.bc.ca/api/v1/docs>
 
 ### General Design
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description
The link to the API documentation was pointing to a defunct route/endpoint.

Corrected the readme link to point to the current endpoint.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
Documentation (non-breaking change with enhancements to documentation)
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [ ] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the OpenAPI 3.0 `v*.api-spec.yaml` documentation (if appropriate)
- [x] I have added necessary documentation (if appropriate)

## Further comments
Assuming a partial checklist okay here, as it is only an edit to a readme.

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
